### PR TITLE
Improved Rescue Prime Hash on `F(2^64 - 2^32 + 1)`

### DIFF
--- a/bench_rescue_prime.cpp
+++ b/bench_rescue_prime.cpp
@@ -1,23 +1,42 @@
 #include "bench_rescue_prime.hpp"
 #include "rescue_prime.hpp"
 
-void benchmark_hash_elements(sycl::queue &q, const uint32_t dim,
-                             const uint32_t wg_size, const uint32_t itr_count) {
-  uint64_t *elements = (uint64_t *)sycl::malloc_device(sizeof(uint64_t) * 8, q);
+int64_t benchmark_hash_elements(sycl::queue &q, const uint32_t dim,
+                                const uint32_t wg_size,
+                                const uint32_t itr_count) {
+  uint64_t *elements =
+      static_cast<uint64_t *>(sycl::malloc_device(sizeof(uint64_t) * 8, q));
+  uint64_t *hashes = static_cast<uint64_t *>(
+      sycl::malloc_device(sizeof(uint64_t) * dim * dim * DIGEST_SIZE, q));
+
   auto evt_0 = q.single_task([=]() {
     for (uint8_t i = 0; i < 8; i++) {
       *(elements + i) = i;
     }
   });
 
+  using tp = std::chrono::_V2::steady_clock::time_point;
+  tp start = std::chrono::steady_clock::now();
+
   auto evt_1 = q.submit([&](sycl::handler &h) {
     h.depends_on({evt_0});
-    h.parallel_for(
+    h.parallel_for<class kernelBenchmarkRescuePrimeHash>(
         sycl::nd_range<2>{sycl::range<2>{dim, dim}, sycl::range<2>{1, wg_size}},
         [=](sycl::nd_item<2> it) {
-          uint64_t hash[DIGEST_SIZE] = {0uLL};
-          hash_elements(elements, 8, hash);
+          const size_t idx = it.get_global_linear_id();
+
+          for (uint32_t i = 0; i < itr_count; i++) {
+            hash_elements(elements, 8, hashes + idx * 4);
+          }
         });
   });
   evt_1.wait();
+
+  tp end = std::chrono::steady_clock::now();
+
+  sycl::free(elements, q);
+  sycl::free(hashes, q);
+
+  return std::chrono::duration_cast<std::chrono::microseconds>(end - start)
+      .count();
 }

--- a/benchmarks/rescue_prime.md
+++ b/benchmarks/rescue_prime.md
@@ -11,15 +11,15 @@ I setup benchmarking with a 2D grid of work-items of dimension N x N, where N = 
 ```bash
 running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
 
-rescue prime hash on F(2**64 - 2**32 + 1) elements 👇                                      
+rescue prime hash on F(2**64 - 2**32 + 1) elements 👇
 
-  dimension             iterations                        total                          avg                            op/s                                                                                                                                                    
-128  x  128                    1                          54666 us                      3.33655 us                       299711                                                                                                                                                 
-256  x  256                    1                         160172 us                      2.44403 us                       409160                                                                                                                                                 
-512  x  512                    1                         635313 us                      2.42353 us                       412622                                                                                                                                                 
-1024 x 1024                    1                        2530078 us                      2.41287 us                       414444                                                                                                                                                 
-2048 x 2048                    1                       10154839 us                       2.4211 us                       413035                                                                                                                                                 
-4096 x 4096                    1                       40395352 us                      2.40775 us                       415325
+  dimension		iterations		          total		                 avg		                op/s
+128  x  128		       1		          49722 us		        3.03479 us		         329512
+256  x  256		       1		         162410 us		        2.47818 us		         403522
+512  x  512		       1		         639436 us		        2.43925 us		         409961
+1024 x 1024		       1		        2538022 us		        2.42045 us		         413147
+2048 x 2048		       1		       10113576 us		        2.41126 us		         414720
+4096 x 4096		       1		       40439263 us		        2.41037 us		         414874
 ```
 
 ```bash
@@ -27,13 +27,13 @@ running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
 
 rescue prime hash on F(2**64 - 2**32 + 1) elements 👇
 
-  dimension             iterations                        total                          avg                            op/s
-128  x  128                    1                          30587 us                      1.86688 us                       535652
-256  x  256                    1                          51024 us                     0.778564 us                  1.28442e+06
-512  x  512                    1                         163562 us                      0.62394 us                  1.60272e+06
-1024 x 1024                    1                         635064 us                     0.605644 us                  1.65113e+06
-2048 x 2048                    1                        2495802 us                     0.595046 us                  1.68054e+06
-4096 x 4096                    1                        8674517 us                     0.517042 us                  1.93408e+06
+  dimension		iterations		          total		                 avg		                op/s
+128  x  128		       1		          25644 us		        1.56519 us		         638902
+256  x  256		       1		          49490 us		       0.755157 us		    1.32423e+06
+512  x  512		       1		         163912 us		       0.625275 us		     1.5993e+06
+1024 x 1024		       1		         636838 us		       0.607336 us		    1.64653e+06
+2048 x 2048		       1		        2491102 us		       0.593925 us		    1.68371e+06
+4096 x 4096		       1		        8382231 us		        0.49962 us		    2.00152e+06
 ```
 
 ### On GPU
@@ -43,11 +43,11 @@ running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
 
 rescue prime hash on F(2**64 - 2**32 + 1) elements 👇
 
-  dimension             iterations                        total                          avg                            op/s
-128  x  128                    1                           1379 us                    0.0841675 us                  1.18811e+07
-256  x  256                    1                            174 us                   0.00265503 us                  3.76644e+08
-512  x  512                    1                            264 us                   0.00100708 us                   9.9297e+08
-1024 x 1024                    1                            828 us                  0.000789642 us                   1.2664e+09
-2048 x 2048                    1                           3100 us                  0.000739098 us                    1.353e+09
-4096 x 4096                    1                          12174 us                  0.000725627 us                  1.37812e+09
+  dimension		iterations		          total		                 avg		                op/s
+128  x  128		       1		          11589 us		       0.707336 us		    1.41375e+06
+256  x  256		       1		          36109 us		        0.55098 us		    1.81495e+06
+512  x  512		       1		         131971 us		       0.503429 us		    1.98638e+06
+1024 x 1024		       1		         521590 us		       0.497427 us		    2.01035e+06
+2048 x 2048		       1		        2076505 us		       0.495077 us		    2.01989e+06
+4096 x 4096		       1		        8334105 us		       0.496751 us		    2.01308e+06
 ```

--- a/benchmarks/rescue_prime.md
+++ b/benchmarks/rescue_prime.md
@@ -1,23 +1,39 @@
 ## Benchmark Rescue Prime Hash on F(2 ** 64 - 2 ** 32 + 1) Elements
 
-I setup benchmarking with a 2D grid of work-items of dimension N x N, where N = {128, 256, 512, 1024}. Each work-item takes an input array of prime field elements of length 8 ( so 512-bit input ) and produces 256-bit output hash, consisting of four prime field elements.
+I setup benchmarking with a 2D grid of work-items of dimension N x N, where N = {128, 256, 512, 1024, 2048, 4096}. Each work-item takes an input array of prime field elements of length 8 ( so 512-bit input ) and produces 256-bit output hash, consisting of four prime field elements.
 
-`hash_elements` function is the only one benchmarked, with AOT compilation enabled for target platform, where workgroup size is set to **128**.
+`hash_elements` function is the only one benchmarked, with AOT compilation enabled for target platform, where workgroup size is set to **64**.
 
-> Current implementation uses USM ( read pointer arithmetics used heavily ) for inteacting with memory systems.
+> Hash state is represented using register files, which is why I notice, on GPU performance is far superior than previous benchmark on GPU, while on CPU reverse trend is present. It makes sense because, on GPU, register files are larger than what it's in CPU. Note, at [commit](https://github.com/itzmeanjan/ff-gpu/blob/27f670fa955b8e33a76741cd364a8dbae7fa1959/benchmarks/rescue_prime.md) benchmark results using indexable arrays, and compare it with current benchmark results. On CPU, too much use of registers, probably resulting into register spilling which puts state data on RAM and access becomes slower, which seems to be reason behind decreased performance on CPU, when indexable arrays are not used. *I intend to keep register based implementation, instead of indexable array based [one](https://github.com/itzmeanjan/ff-gpu/blob/27f670fa955b8e33a76741cd364a8dbae7fa1959/rescue_prime.cpp), as my major interest is to get better performance when running on GPU.*
 
 ### On CPU
 
 ```bash
 running on Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz
 
+rescue prime hash on F(2**64 - 2**32 + 1) elements 👇                                      
+
+  dimension             iterations                        total                          avg                            op/s                                                                                                                                                    
+128  x  128                    1                          54666 us                      3.33655 us                       299711                                                                                                                                                 
+256  x  256                    1                         160172 us                      2.44403 us                       409160                                                                                                                                                 
+512  x  512                    1                         635313 us                      2.42353 us                       412622                                                                                                                                                 
+1024 x 1024                    1                        2530078 us                      2.41287 us                       414444                                                                                                                                                 
+2048 x 2048                    1                       10154839 us                       2.4211 us                       413035                                                                                                                                                 
+4096 x 4096                    1                       40395352 us                      2.40775 us                       415325
+```
+
+```bash
+running on Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz
+
 rescue prime hash on F(2**64 - 2**32 + 1) elements 👇
 
   dimension             iterations                        total                          avg                            op/s
-128  x  128                    1                          54202 us                      3.30823 us                       302277
-256  x  256                    1                         157476 us                      2.40289 us                       416165
-512  x  512                    1                         603811 us                      2.30336 us                       434149
-1024 x 1024                    1                        2379147 us                      2.26893 us                       440736
+128  x  128                    1                          30587 us                      1.86688 us                       535652
+256  x  256                    1                          51024 us                     0.778564 us                  1.28442e+06
+512  x  512                    1                         163562 us                      0.62394 us                  1.60272e+06
+1024 x 1024                    1                         635064 us                     0.605644 us                  1.65113e+06
+2048 x 2048                    1                        2495802 us                     0.595046 us                  1.68054e+06
+4096 x 4096                    1                        8674517 us                     0.517042 us                  1.93408e+06
 ```
 
 ### On GPU
@@ -28,8 +44,10 @@ running on Intel(R) Iris(R) Xe MAX Graphics [0x4905]
 rescue prime hash on F(2**64 - 2**32 + 1) elements 👇
 
   dimension             iterations                        total                          avg                            op/s
-128  x  128                    1                        2428612 us                      148.231 us                      6746.24
-256  x  256                    1                          31218 us                     0.476349 us                   2.0993e+06
-512  x  512                    1                         107906 us                     0.411629 us                  2.42937e+06
-1024 x 1024                    1                         433583 us                     0.413497 us                   2.4184e+06
+128  x  128                    1                           1379 us                    0.0841675 us                  1.18811e+07
+256  x  256                    1                            174 us                   0.00265503 us                  3.76644e+08
+512  x  512                    1                            264 us                   0.00100708 us                   9.9297e+08
+1024 x 1024                    1                            828 us                  0.000789642 us                   1.2664e+09
+2048 x 2048                    1                           3100 us                  0.000739098 us                    1.353e+09
+4096 x 4096                    1                          12174 us                  0.000725627 us                  1.37812e+09
 ```

--- a/include/bench_rescue_prime.hpp
+++ b/include/bench_rescue_prime.hpp
@@ -1,5 +1,5 @@
 #pragma once
 #include <CL/sycl.hpp>
 
-void benchmark_hash_elements(sycl::queue &q, const uint32_t dim,
+int64_t benchmark_hash_elements(sycl::queue &q, const uint32_t dim,
                              const uint32_t wg_size, const uint32_t itr_count);

--- a/include/rescue_prime.hpp
+++ b/include/rescue_prime.hpp
@@ -6,28 +6,42 @@ inline constexpr uint64_t RATE_WIDTH = 8;
 inline constexpr uint64_t DIGEST_SIZE = 4;
 inline constexpr uint64_t NUM_ROUNDS = 7;
 
+typedef struct rescue_prime_state_t {
+  uint64_t f_0 = 0, f_1 = 0, f_2 = 0, f_3 = 0, f_4 = 0, f_5 = 0, f_6 = 0,
+           f_7 = 0, f_8 = 0, f_9 = 0, f_a = 0, f_b = 0;
+} rescue_prime_state_t;
+
 extern SYCL_EXTERNAL void hash_elements(const uint64_t *elements,
                                         const uint64_t count,
                                         uint64_t *const hash);
 
-extern SYCL_EXTERNAL void apply_permutation(uint64_t *const state);
+extern SYCL_EXTERNAL void apply_permutation(rescue_prime_state_t *state);
 
-extern SYCL_EXTERNAL void apply_round(uint64_t *const state,
+extern SYCL_EXTERNAL void apply_round(rescue_prime_state_t *state,
                                       const uint64_t round);
 
-extern SYCL_EXTERNAL void apply_sbox(uint64_t *const state);
+extern SYCL_EXTERNAL void apply_sbox(rescue_prime_state_t *state);
 
-extern SYCL_EXTERNAL void apply_mds(uint64_t *state);
+extern SYCL_EXTERNAL uint64_t element_wise_accumulation(
+    rescue_prime_state_t *state_a, rescue_prime_state_t state_b);
 
-extern SYCL_EXTERNAL void apply_constants(uint64_t *const state,
-                                          const uint64_t *ark);
+extern SYCL_EXTERNAL void apply_mds(rescue_prime_state_t *state);
 
-extern SYCL_EXTERNAL void apply_inv_sbox(uint64_t *const state);
+extern SYCL_EXTERNAL void apply_constants(rescue_prime_state_t *state,
+                                          rescue_prime_state_t ark);
 
-extern SYCL_EXTERNAL void exp_acc(const uint64_t m, const uint64_t *base,
-                                  const uint64_t *tail, uint64_t *const res);
+extern SYCL_EXTERNAL void
+element_wise_multiplication(rescue_prime_state_t *state_src_a,
+                            rescue_prime_state_t *state_src_b,
+                            rescue_prime_state_t *state_dst);
 
-inline constexpr uint64_t MDS[STATE_WIDTH][STATE_WIDTH] = {
+extern SYCL_EXTERNAL void apply_inv_sbox(rescue_prime_state_t *state);
+
+extern SYCL_EXTERNAL void exp_acc(const uint64_t m, rescue_prime_state_t *base,
+                                  rescue_prime_state_t *tail,
+                                  rescue_prime_state_t *res);
+
+inline constexpr rescue_prime_state_t MDS[STATE_WIDTH] = {
     {
         2108866337646019936ull % MOD,
         11223275256334781131ull % MOD,
@@ -197,7 +211,7 @@ inline constexpr uint64_t MDS[STATE_WIDTH][STATE_WIDTH] = {
         5548519654341606996ull % MOD,
     }};
 
-inline constexpr uint64_t ARK1[NUM_ROUNDS][STATE_WIDTH] = {
+inline constexpr rescue_prime_state_t ARK1[NUM_ROUNDS] = {
     {
         13917550007135091859ull % MOD,
         16002276252647722320ull % MOD,
@@ -297,7 +311,7 @@ inline constexpr uint64_t ARK1[NUM_ROUNDS][STATE_WIDTH] = {
         7431110942091427450ull % MOD,
     }};
 
-inline constexpr uint64_t ARK2[NUM_ROUNDS][STATE_WIDTH] = {
+inline constexpr rescue_prime_state_t ARK2[NUM_ROUNDS] = {
     {
         7989257206380839449ull % MOD,
         8639509123020237648ull % MOD,

--- a/include/test_rescue_prime.hpp
+++ b/include/test_rescue_prime.hpp
@@ -10,7 +10,7 @@ void test_alphas(sycl::queue &q);
 
 void test_sbox(sycl::queue &q);
 
-void random_array(uint64_t *const arr, const uint64_t count);
+void random_rescue_prime_state(rescue_prime_state_t *arr);
 
 void test_inv_sbox(sycl::queue &q);
 

--- a/main.cpp
+++ b/main.cpp
@@ -339,13 +339,10 @@ int main(int argc, char **argv) {
             << "\t\t" << std::setw(20) << "op/s" << std::endl;
 
   for (uint dim = B; dim <= (1ul << 12); dim <<= 1) {
-    tp start = std::chrono::steady_clock::now();
-    benchmark_hash_elements(q, dim, 1ul << 6, N);
-    tp end = std::chrono::steady_clock::now();
+    // note iteration count is set to 1, so each work-item
+    // only hashes input one time
+    int64_t tm = benchmark_hash_elements(q, dim, 1ul << 6, 1);
 
-    int64_t tm =
-        std::chrono::duration_cast<std::chrono::microseconds>(end - start)
-            .count();
     std::cout << std::setw(5) << std::left << dim << "x" << std::setw(5)
               << std::right << dim << "\t\t" << std::setw(8) << std::right << 1
               << "\t\t" << std::setw(15) << std::right << tm << " us"

--- a/main.cpp
+++ b/main.cpp
@@ -338,9 +338,9 @@ int main(int argc, char **argv) {
             << "\t\t" << std::setw(20) << "avg"
             << "\t\t" << std::setw(20) << "op/s" << std::endl;
 
-  for (uint dim = B; dim <= N; dim <<= 1) {
+  for (uint dim = B; dim <= (1ul << 12); dim <<= 1) {
     tp start = std::chrono::steady_clock::now();
-    benchmark_hash_elements(q, dim, B, N);
+    benchmark_hash_elements(q, dim, 1ul << 6, N);
     tp end = std::chrono::steady_clock::now();
 
     int64_t tm =

--- a/rescue_prime.cpp
+++ b/rescue_prime.cpp
@@ -2,35 +2,63 @@
 
 void hash_elements(const uint64_t *elements, const uint64_t count,
                    uint64_t *const hash) {
-  uint64_t state[STATE_WIDTH] = {0};
-  state[STATE_WIDTH - 1] = count >= MOD ? count - MOD : count;
+  rescue_prime_state_t state{.f_b = count >= MOD ? count - MOD : count};
 
   uint64_t i = 0;
   for (uint64_t j = 0; j < count; j++) {
-    state[i] = ff_p_add(state[i], *(elements + j));
+    switch (i) {
+    case 0:
+      state.f_0 = ff_p_add(state.f_0, *(elements + j));
+      break;
+    case 1:
+      state.f_1 = ff_p_add(state.f_1, *(elements + j));
+      break;
+    case 2:
+      state.f_2 = ff_p_add(state.f_2, *(elements + j));
+      break;
+    case 3:
+      state.f_3 = ff_p_add(state.f_3, *(elements + j));
+      break;
+    case 4:
+      state.f_4 = ff_p_add(state.f_4, *(elements + j));
+      break;
+    case 5:
+      state.f_5 = ff_p_add(state.f_5, *(elements + j));
+      break;
+    case 6:
+      state.f_6 = ff_p_add(state.f_6, *(elements + j));
+      break;
+    case 7:
+      state.f_7 = ff_p_add(state.f_7, *(elements + j));
+      break;
+    default:
+      // we should not reach to this condition ever !
+      break;
+    }
     i++;
     if (i % RATE_WIDTH == 0) {
-      apply_permutation(state);
+      apply_permutation(&state);
       i = 0;
     }
   }
 
   if (i > 0) {
-    apply_permutation(state);
+    apply_permutation(&state);
   }
 
-  for (uint64_t i = 0; i < DIGEST_SIZE; i++) {
-    *(hash + i) = state[i];
-  }
+  *(hash + 0) = state.f_0;
+  *(hash + 1) = state.f_1;
+  *(hash + 2) = state.f_2;
+  *(hash + 3) = state.f_3;
 }
 
-void apply_permutation(uint64_t *const state) {
+void apply_permutation(rescue_prime_state_t *state) {
   for (uint64_t i = 0; i < NUM_ROUNDS; i++) {
     apply_round(state, i);
   }
 }
 
-void apply_round(uint64_t *const state, const uint64_t round) {
+void apply_round(rescue_prime_state_t *state, const uint64_t round) {
   apply_sbox(state);
   apply_mds(state);
   apply_constants(state, ARK1[round]);
@@ -40,83 +68,249 @@ void apply_round(uint64_t *const state, const uint64_t round) {
   apply_constants(state, ARK2[round]);
 }
 
-void apply_sbox(uint64_t *const state) {
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    uint64_t t2 = ff_p_mult(*(state + i), *(state + i));
-    uint64_t t4 = ff_p_mult(t2, t2);
+void apply_sbox(rescue_prime_state_t *state) {
+  uint64_t t2 = 0ul, t4 = 0ul;
 
-    *(state + i) = ff_p_mult(*(state + i), ff_p_mult(t2, t4));
-  }
+  t2 = ff_p_mult(state->f_0, state->f_0);
+  t4 = ff_p_mult(t2, t2);
+  state->f_0 = ff_p_mult(state->f_0, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_1, state->f_1);
+  t4 = ff_p_mult(t2, t2);
+  state->f_1 = ff_p_mult(state->f_1, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_2, state->f_2);
+  t4 = ff_p_mult(t2, t2);
+  state->f_2 = ff_p_mult(state->f_2, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_3, state->f_3);
+  t4 = ff_p_mult(t2, t2);
+  state->f_3 = ff_p_mult(state->f_3, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_4, state->f_4);
+  t4 = ff_p_mult(t2, t2);
+  state->f_4 = ff_p_mult(state->f_4, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_5, state->f_5);
+  t4 = ff_p_mult(t2, t2);
+  state->f_5 = ff_p_mult(state->f_5, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_6, state->f_6);
+  t4 = ff_p_mult(t2, t2);
+  state->f_6 = ff_p_mult(state->f_6, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_7, state->f_7);
+  t4 = ff_p_mult(t2, t2);
+  state->f_7 = ff_p_mult(state->f_7, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_8, state->f_8);
+  t4 = ff_p_mult(t2, t2);
+  state->f_8 = ff_p_mult(state->f_8, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_9, state->f_9);
+  t4 = ff_p_mult(t2, t2);
+  state->f_9 = ff_p_mult(state->f_9, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_a, state->f_a);
+  t4 = ff_p_mult(t2, t2);
+  state->f_a = ff_p_mult(state->f_a, ff_p_mult(t2, t4));
+
+  t2 = ff_p_mult(state->f_b, state->f_b);
+  t4 = ff_p_mult(t2, t2);
+  state->f_b = ff_p_mult(state->f_b, ff_p_mult(t2, t4));
 }
 
-void apply_mds(uint64_t *state) {
-  uint64_t res[STATE_WIDTH] = {0};
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    for (uint64_t j = 0; j < STATE_WIDTH; j++) {
-      res[i] = ff_p_add(res[i], ff_p_mult(MDS[i][j], *(state + j)));
-    }
-  }
+uint64_t element_wise_accumulation(rescue_prime_state_t *state_a,
+                                   rescue_prime_state_t state_b) {
+  uint64_t res = 0ul;
 
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    *(state + i) = res[i];
-  }
+  res = ff_p_add(res, ff_p_mult(state_a->f_0, state_b.f_0));
+  res = ff_p_add(res, ff_p_mult(state_a->f_1, state_b.f_1));
+  res = ff_p_add(res, ff_p_mult(state_a->f_2, state_b.f_2));
+  res = ff_p_add(res, ff_p_mult(state_a->f_3, state_b.f_3));
+  res = ff_p_add(res, ff_p_mult(state_a->f_4, state_b.f_4));
+  res = ff_p_add(res, ff_p_mult(state_a->f_5, state_b.f_5));
+  res = ff_p_add(res, ff_p_mult(state_a->f_6, state_b.f_6));
+  res = ff_p_add(res, ff_p_mult(state_a->f_7, state_b.f_7));
+  res = ff_p_add(res, ff_p_mult(state_a->f_8, state_b.f_8));
+  res = ff_p_add(res, ff_p_mult(state_a->f_9, state_b.f_9));
+  res = ff_p_add(res, ff_p_mult(state_a->f_a, state_b.f_a));
+  res = ff_p_add(res, ff_p_mult(state_a->f_b, state_b.f_b));
+
+  return res;
 }
 
-void apply_constants(uint64_t *const state, const uint64_t *ark) {
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    *(state + i) = ff_p_add(*(state + i), *(ark + i));
-  }
+void apply_mds(rescue_prime_state_t *state) {
+  rescue_prime_state_t res;
+
+  res.f_0 = element_wise_accumulation(state, MDS[0]);
+  res.f_1 = element_wise_accumulation(state, MDS[1]);
+  res.f_2 = element_wise_accumulation(state, MDS[2]);
+  res.f_3 = element_wise_accumulation(state, MDS[3]);
+  res.f_4 = element_wise_accumulation(state, MDS[4]);
+  res.f_5 = element_wise_accumulation(state, MDS[5]);
+  res.f_6 = element_wise_accumulation(state, MDS[6]);
+  res.f_7 = element_wise_accumulation(state, MDS[7]);
+  res.f_8 = element_wise_accumulation(state, MDS[8]);
+  res.f_9 = element_wise_accumulation(state, MDS[9]);
+  res.f_a = element_wise_accumulation(state, MDS[10]);
+  res.f_b = element_wise_accumulation(state, MDS[11]);
+
+  state->f_0 = res.f_0;
+  state->f_1 = res.f_1;
+  state->f_2 = res.f_2;
+  state->f_3 = res.f_3;
+  state->f_4 = res.f_4;
+  state->f_5 = res.f_5;
+  state->f_6 = res.f_6;
+  state->f_7 = res.f_7;
+  state->f_8 = res.f_8;
+  state->f_9 = res.f_9;
+  state->f_a = res.f_a;
+  state->f_b = res.f_b;
 }
 
-void apply_inv_sbox(uint64_t *const state) {
-  uint64_t t1[STATE_WIDTH] = {0};
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    t1[i] = ff_p_mult(*(state + i), *(state + i));
-  }
-
-  uint64_t t2[STATE_WIDTH] = {0};
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    t2[i] = ff_p_mult(t1[i], t1[i]);
-  }
-
-  uint64_t t3[STATE_WIDTH] = {0};
-  exp_acc(3, t2, t2, t3);
-
-  uint64_t t4[STATE_WIDTH] = {0};
-  exp_acc(6, t3, t3, t4);
-
-  uint64_t tmp[STATE_WIDTH] = {0};
-  exp_acc(12, t4, t4, tmp);
-
-  uint64_t t5[STATE_WIDTH] = {0};
-  exp_acc(6, tmp, t3, t5);
-
-  uint64_t t6[STATE_WIDTH] = {0};
-  exp_acc(31, t5, t5, t6);
-
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    uint64_t a = ff_p_mult(ff_p_mult(t6[i], t6[i]), t5[i]);
-    a = ff_p_mult(a, a);
-    a = ff_p_mult(a, a);
-    uint64_t b = ff_p_mult(ff_p_mult(t1[i], t2[i]), *(state + i));
-
-    *(state + i) = ff_p_mult(a, b);
-  }
+void apply_constants(rescue_prime_state_t *state, rescue_prime_state_t ark) {
+  state->f_0 = ff_p_add(state->f_0, ark.f_0);
+  state->f_1 = ff_p_add(state->f_1, ark.f_1);
+  state->f_2 = ff_p_add(state->f_2, ark.f_2);
+  state->f_3 = ff_p_add(state->f_3, ark.f_3);
+  state->f_4 = ff_p_add(state->f_4, ark.f_4);
+  state->f_5 = ff_p_add(state->f_5, ark.f_5);
+  state->f_6 = ff_p_add(state->f_6, ark.f_6);
+  state->f_7 = ff_p_add(state->f_7, ark.f_7);
+  state->f_8 = ff_p_add(state->f_8, ark.f_8);
+  state->f_9 = ff_p_add(state->f_9, ark.f_9);
+  state->f_a = ff_p_add(state->f_a, ark.f_a);
+  state->f_b = ff_p_add(state->f_b, ark.f_b);
 }
 
-void exp_acc(const uint64_t m, const uint64_t *base, const uint64_t *tail,
-             uint64_t *const res) {
+void element_wise_multiplication(rescue_prime_state_t *state_src_a,
+                                 rescue_prime_state_t *state_src_b,
+                                 rescue_prime_state_t *state_dst) {
+  state_dst->f_0 = ff_p_mult(state_src_a->f_0, state_src_b->f_0);
+  state_dst->f_1 = ff_p_mult(state_src_a->f_1, state_src_b->f_1);
+  state_dst->f_2 = ff_p_mult(state_src_a->f_2, state_src_b->f_2);
+  state_dst->f_3 = ff_p_mult(state_src_a->f_3, state_src_b->f_3);
+
+  state_dst->f_4 = ff_p_mult(state_src_a->f_4, state_src_b->f_4);
+  state_dst->f_5 = ff_p_mult(state_src_a->f_5, state_src_b->f_5);
+  state_dst->f_6 = ff_p_mult(state_src_a->f_6, state_src_b->f_6);
+  state_dst->f_7 = ff_p_mult(state_src_a->f_7, state_src_b->f_7);
+
+  state_dst->f_8 = ff_p_mult(state_src_a->f_8, state_src_b->f_8);
+  state_dst->f_9 = ff_p_mult(state_src_a->f_9, state_src_b->f_9);
+  state_dst->f_a = ff_p_mult(state_src_a->f_a, state_src_b->f_a);
+  state_dst->f_b = ff_p_mult(state_src_a->f_b, state_src_b->f_b);
+}
+
+void apply_inv_sbox(rescue_prime_state_t *state) {
+  rescue_prime_state_t t1;
+  element_wise_multiplication(state, state, &t1);
+
+  rescue_prime_state_t t2;
+  element_wise_multiplication(&t1, &t1, &t2);
+
+  rescue_prime_state_t t3;
+  exp_acc(3, &t2, &t2, &t3);
+
+  rescue_prime_state_t t4;
+  exp_acc(6, &t3, &t3, &t4);
+
+  rescue_prime_state_t tmp;
+  exp_acc(12, &t4, &t4, &tmp);
+
+  rescue_prime_state_t t5;
+  exp_acc(6, &tmp, &t3, &t5);
+
+  rescue_prime_state_t t6;
+  exp_acc(31, &t5, &t5, &t6);
+
+  // declare one time, use same registers multiple times
+  uint64_t a = 0ul, b = 0ul;
+
+  a = ff_p_mult(t5.f_0, ff_p_mult(t6.f_0, t6.f_0));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_0, ff_p_mult(t1.f_0, t2.f_0));
+  state->f_0 = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_1, ff_p_mult(t6.f_1, t6.f_1));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_1, ff_p_mult(t1.f_1, t2.f_1));
+  state->f_1 = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_2, ff_p_mult(t6.f_2, t6.f_2));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_2, ff_p_mult(t1.f_2, t2.f_2));
+  state->f_2 = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_3, ff_p_mult(t6.f_3, t6.f_3));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_3, ff_p_mult(t1.f_3, t2.f_3));
+  state->f_3 = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_4, ff_p_mult(t6.f_4, t6.f_4));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_4, ff_p_mult(t1.f_4, t2.f_4));
+  state->f_4 = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_5, ff_p_mult(t6.f_5, t6.f_5));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_5, ff_p_mult(t1.f_5, t2.f_5));
+  state->f_5 = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_6, ff_p_mult(t6.f_6, t6.f_6));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_6, ff_p_mult(t1.f_6, t2.f_6));
+  state->f_6 = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_7, ff_p_mult(t6.f_7, t6.f_7));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_7, ff_p_mult(t1.f_7, t2.f_7));
+  state->f_7 = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_8, ff_p_mult(t6.f_8, t6.f_8));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_8, ff_p_mult(t1.f_8, t2.f_8));
+  state->f_8 = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_9, ff_p_mult(t6.f_9, t6.f_9));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_9, ff_p_mult(t1.f_9, t2.f_9));
+  state->f_9 = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_a, ff_p_mult(t6.f_a, t6.f_a));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_a, ff_p_mult(t1.f_a, t2.f_a));
+  state->f_a = ff_p_mult(a, b);
+
+  a = ff_p_mult(t5.f_b, ff_p_mult(t6.f_b, t6.f_b));
+  a = ff_p_mult(a, a);
+  a = ff_p_mult(a, a);
+  b = ff_p_mult(state->f_b, ff_p_mult(t1.f_b, t2.f_b));
+  state->f_b = ff_p_mult(a, b);
+}
+
+void exp_acc(const uint64_t m, rescue_prime_state_t *base,
+             rescue_prime_state_t *tail, rescue_prime_state_t *res) {
   for (uint64_t i = 0; i < m; i++) {
-    for (uint64_t j = 0; j < STATE_WIDTH; j++) {
-      if (i == 0) {
-        *(res + j) = ff_p_mult(*(base + j), *(base + j));
-      } else {
-        *(res + j) = ff_p_mult(*(res + j), *(res + j));
-      }
+    if (i == 0) {
+      element_wise_multiplication(base, base, res);
+    } else {
+      element_wise_multiplication(res, res, res);
     }
   }
 
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    *(res + i) = ff_p_mult(*(res + i), *(tail + i));
-  }
+  element_wise_multiplication(res, tail, res);
 }

--- a/tests/test_rescue_prime.cpp
+++ b/tests/test_rescue_prime.cpp
@@ -12,61 +12,108 @@ void test_alphas(sycl::queue &q) {
 }
 
 void test_sbox(sycl::queue &q) {
-  uint64_t *arr_0 =
-      (uint64_t *)sycl::malloc_shared(sizeof(uint64_t) * STATE_WIDTH, q);
-  uint64_t *arr_1 =
-      (uint64_t *)sycl::malloc_shared(sizeof(uint64_t) * STATE_WIDTH, q);
+  rescue_prime_state_t *arr_0 = (rescue_prime_state_t *)sycl::malloc_shared(
+      sizeof(rescue_prime_state_t), q);
+  rescue_prime_state_t *arr_1 = (rescue_prime_state_t *)sycl::malloc_shared(
+      sizeof(rescue_prime_state_t), q);
 
-  random_array(arr_0, STATE_WIDTH);
-  q.memcpy(arr_1, arr_0, sizeof(uint64_t) * STATE_WIDTH).wait();
+  random_rescue_prime_state(arr_0);
+  q.memcpy(arr_1, arr_0, sizeof(rescue_prime_state_t)).wait();
   q.single_task([=]() { apply_sbox(arr_0); });
 
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    *(arr_1 + i) = operate(q, *(arr_1 + i), ALPHA, Op::power);
-  }
+  arr_1->f_0 = operate(q, arr_1->f_0, ALPHA, Op::power);
+  arr_1->f_1 = operate(q, arr_1->f_1, ALPHA, Op::power);
+  arr_1->f_2 = operate(q, arr_1->f_2, ALPHA, Op::power);
+  arr_1->f_3 = operate(q, arr_1->f_3, ALPHA, Op::power);
+  arr_1->f_4 = operate(q, arr_1->f_4, ALPHA, Op::power);
+  arr_1->f_5 = operate(q, arr_1->f_5, ALPHA, Op::power);
+  arr_1->f_6 = operate(q, arr_1->f_6, ALPHA, Op::power);
+  arr_1->f_7 = operate(q, arr_1->f_7, ALPHA, Op::power);
+  arr_1->f_8 = operate(q, arr_1->f_8, ALPHA, Op::power);
+  arr_1->f_9 = operate(q, arr_1->f_9, ALPHA, Op::power);
+  arr_1->f_a = operate(q, arr_1->f_a, ALPHA, Op::power);
+  arr_1->f_b = operate(q, arr_1->f_b, ALPHA, Op::power);
 
   q.wait();
 
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    assert(*(arr_0 + i) == *(arr_1 + i));
-  }
+  assert(arr_0->f_0 == arr_1->f_0);
+  assert(arr_0->f_1 == arr_1->f_1);
+  assert(arr_0->f_2 == arr_1->f_2);
+  assert(arr_0->f_3 == arr_1->f_3);
+  assert(arr_0->f_4 == arr_1->f_4);
+  assert(arr_0->f_5 == arr_1->f_5);
+  assert(arr_0->f_6 == arr_1->f_6);
+  assert(arr_0->f_7 == arr_1->f_7);
+  assert(arr_0->f_8 == arr_1->f_8);
+  assert(arr_0->f_9 == arr_1->f_9);
+  assert(arr_0->f_a == arr_1->f_a);
+  assert(arr_0->f_b == arr_1->f_b);
 }
 
-void random_array(uint64_t *const arr, const uint64_t count) {
+void random_rescue_prime_state(rescue_prime_state_t *arr) {
   std::random_device rd;
   std::mt19937 gen(rd());
   std::uniform_int_distribution<uint64_t> dis(0, UINT64_MAX);
 
-  for (uint64_t i = 0; i < count; i++) {
-    *(arr + i) = dis(gen) % MOD;
-  }
+  arr->f_0 = dis(gen) % MOD;
+  arr->f_1 = dis(gen) % MOD;
+  arr->f_2 = dis(gen) % MOD;
+  arr->f_3 = dis(gen) % MOD;
+
+  arr->f_4 = dis(gen) % MOD;
+  arr->f_5 = dis(gen) % MOD;
+  arr->f_6 = dis(gen) % MOD;
+  arr->f_7 = dis(gen) % MOD;
+
+  arr->f_8 = dis(gen) % MOD;
+  arr->f_9 = dis(gen) % MOD;
+  arr->f_a = dis(gen) % MOD;
+  arr->f_b = dis(gen) % MOD;
 }
 
 void test_inv_sbox(sycl::queue &q) {
-  uint64_t *arr_0 =
-      (uint64_t *)sycl::malloc_shared(sizeof(uint64_t) * STATE_WIDTH, q);
-  uint64_t *arr_1 =
-      (uint64_t *)sycl::malloc_shared(sizeof(uint64_t) * STATE_WIDTH, q);
+  rescue_prime_state_t *arr_0 = (rescue_prime_state_t *)sycl::malloc_shared(
+      sizeof(rescue_prime_state_t), q);
+  rescue_prime_state_t *arr_1 = (rescue_prime_state_t *)sycl::malloc_shared(
+      sizeof(rescue_prime_state_t), q);
 
-  random_array(arr_0, STATE_WIDTH);
-  q.memcpy(arr_1, arr_0, sizeof(uint64_t) * STATE_WIDTH).wait();
+  random_rescue_prime_state(arr_0);
+  q.memcpy(arr_1, arr_0, sizeof(rescue_prime_state_t)).wait();
   q.single_task([=]() { apply_inv_sbox(arr_0); });
 
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    *(arr_1 + i) = operate(q, *(arr_1 + i), INV_ALPHA, Op::power);
-  }
+  arr_1->f_0 = operate(q, arr_1->f_0, INV_ALPHA, Op::power);
+  arr_1->f_1 = operate(q, arr_1->f_1, INV_ALPHA, Op::power);
+  arr_1->f_2 = operate(q, arr_1->f_2, INV_ALPHA, Op::power);
+  arr_1->f_3 = operate(q, arr_1->f_3, INV_ALPHA, Op::power);
+  arr_1->f_4 = operate(q, arr_1->f_4, INV_ALPHA, Op::power);
+  arr_1->f_5 = operate(q, arr_1->f_5, INV_ALPHA, Op::power);
+  arr_1->f_6 = operate(q, arr_1->f_6, INV_ALPHA, Op::power);
+  arr_1->f_7 = operate(q, arr_1->f_7, INV_ALPHA, Op::power);
+  arr_1->f_8 = operate(q, arr_1->f_8, INV_ALPHA, Op::power);
+  arr_1->f_9 = operate(q, arr_1->f_9, INV_ALPHA, Op::power);
+  arr_1->f_a = operate(q, arr_1->f_a, INV_ALPHA, Op::power);
+  arr_1->f_b = operate(q, arr_1->f_b, INV_ALPHA, Op::power);
 
   q.wait();
 
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    assert(*(arr_0 + i) == *(arr_1 + i));
-  }
+  assert(arr_0->f_0 == arr_1->f_0);
+  assert(arr_0->f_1 == arr_1->f_1);
+  assert(arr_0->f_2 == arr_1->f_2);
+  assert(arr_0->f_3 == arr_1->f_3);
+  assert(arr_0->f_4 == arr_1->f_4);
+  assert(arr_0->f_5 == arr_1->f_5);
+  assert(arr_0->f_6 == arr_1->f_6);
+  assert(arr_0->f_7 == arr_1->f_7);
+  assert(arr_0->f_8 == arr_1->f_8);
+  assert(arr_0->f_9 == arr_1->f_9);
+  assert(arr_0->f_a == arr_1->f_a);
+  assert(arr_0->f_b == arr_1->f_b);
 }
 
 void test_permutation(sycl::queue &q) {
-  uint64_t *state =
-      (uint64_t *)sycl::malloc_shared(sizeof(uint64_t) * STATE_WIDTH, q);
-  uint64_t expected[STATE_WIDTH] = {
+  rescue_prime_state_t *state = (rescue_prime_state_t *)sycl::malloc_shared(
+      sizeof(rescue_prime_state_t), q);
+  rescue_prime_state_t expected = {
       10809974140050983728ull % MOD, 6938491977181280539ull % MOD,
       8834525837561071698ull % MOD,  6854417192438540779ull % MOD,
       4476630872663101667ull % MOD,  6292749486700362097ull % MOD,
@@ -75,13 +122,31 @@ void test_permutation(sycl::queue &q) {
       9030271581669113292ull % MOD,  10101107035874348250ull % MOD,
   };
 
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    *(state + i) = i;
-  }
+  state->f_0 = 0;
+  state->f_1 = 1;
+  state->f_2 = 2;
+  state->f_3 = 3;
+  state->f_4 = 4;
+  state->f_5 = 5;
+  state->f_6 = 6;
+  state->f_7 = 7;
+  state->f_8 = 8;
+  state->f_9 = 9;
+  state->f_a = 10;
+  state->f_b = 11;
 
   q.single_task([=]() { apply_permutation(state); }).wait();
 
-  for (uint64_t i = 0; i < STATE_WIDTH; i++) {
-    assert(*(state + i) == expected[i]);
-  }
+  assert(state->f_0 == expected.f_0);
+  assert(state->f_1 == expected.f_1);
+  assert(state->f_2 == expected.f_2);
+  assert(state->f_3 == expected.f_3);
+  assert(state->f_4 == expected.f_4);
+  assert(state->f_5 == expected.f_5);
+  assert(state->f_6 == expected.f_6);
+  assert(state->f_7 == expected.f_7);
+  assert(state->f_8 == expected.f_8);
+  assert(state->f_9 == expected.f_9);
+  assert(state->f_a == expected.f_a);
+  assert(state->f_b == expected.f_b);
 }


### PR DESCRIPTION
I've implemented an improved version of Rescue Prime hash function, which performs ~1000x better than previous implementation.

On GPU, register files are larger compared to CPU, so I make use of registers for keeping/ manipulating hash function state. Previous implementation used indexed private arrays, but as register memory can't be indexed, state was kept on global memory, which costs lots of cycles to access. During life cycle of Rescue prime hash function, when permutations are applied, state is updated frequently. Previous implementation had to access global memory too many times, that with no help of coaleseced memory access, because Rescue Prime hash function implementation is not itself parallel. Rather multiple instances of single threaded algorithm is run in parallel on distinct input data. 

Today I implemented it such that state is kept on register files, which are much faster to access compared to global memory. As expected on CPU performance degrades, while on GPU it shines.

I suspect on CPU register spilling is happening too often, resulting into transferring spilled data to global memory ( RAM ), which costs cycles. On the other hand on GPU, that chance is lower, due to presence of much larger register files. 

Device | Previous (Hash/ s) | Current (Hash/ s)
--- | --- | ---
Intel(R) Xeon(R) Gold 6128 CPU @ 3.40GHz | 440736 | 415325
Intel(R) Iris(R) Xe MAX Graphics | 2.4184e+06 | 1.37812e+09

[Here](https://github.com/itzmeanjan/ff-gpu/blob/a8aeeb1d811f13ad376091386ae5655ebc35d9de/benchmarks/rescue_prime.md) is more detailed view of benchmark results. 