### PR TITLE
Accelerated Merkle Tree Construction using Rescue Prime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,12 @@ format:
 tests/ff_p.o: ff_p.cpp
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c $^ -o $@ $(INCLUDES)
 
+tests/merkle_tree.o: merkle_tree.cpp
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c $^ -o $@ $(INCLUDES)
+
+tests/test_merkle_tree.o: tests/test_merkle_tree.cpp
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c $^ -o $@ $(INCLUDES)
+
 tests/rescue_prime.o: rescue_prime.cpp
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c $^ -o $@ $(INCLUDES)
 
@@ -78,7 +84,7 @@ tests/test.o:	tests/test.cpp
 tests/main.o: tests/main.cpp
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c $^ -o $@ $(INCLUDES)
 
-test: tests/ff_p.o tests/rescue_prime.o tests/test_rescue_prime.o tests/ntt.o tests/test_ntt.o tests/test.o tests/main.o
+test: tests/ff_p.o tests/merkle_tree.o tests/test_merkle_tree.o tests/rescue_prime.o tests/test_rescue_prime.o tests/ntt.o tests/test_ntt.o tests/test.o tests/main.o
 	$(CXX) $(SYCLFLAGS) $^ -o tests/$@
 	@./tests/$@
 

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,13 @@ PROG = run
 # otherwise SYCL runtime will panic, when it won't find desired target device
 DFLAGS = -D$(shell echo $(or $(DEVICE),default) | tr a-z A-Z)
 
-$(PROG): main.o utils.o bench_rescue_prime.o bench_ntt.o ff_p.o rescue_prime.o ntt.o test_ntt.o
+$(PROG): main.o utils.o bench_rescue_prime.o bench_ntt.o bench_merkle_tree.o merkle_tree.o ff_p.o rescue_prime.o ntt.o test_ntt.o
 	$(CXX) $(SYCLFLAGS) $^ -o $@
 
 test_ntt.o: tests/test_ntt.cpp include/test_ntt.hpp
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c $^ $(INCLUDES)
+
+merkle_tree.o: merkle_tree.cpp include/merkle_tree.hpp
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c $^ $(INCLUDES)
 
 ntt.o: ntt.cpp include/ntt.hpp
@@ -31,6 +34,9 @@ rescue_prime.o: rescue_prime.cpp include/rescue_prime.hpp
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c $^ $(INCLUDES)
 
 ff_p.o: ff_p.cpp include/ff_p.hpp
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c $^ $(INCLUDES)
+
+bench_merkle_tree.o: bench_merkle_tree.cpp include/bench_merkle_tree.hpp
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c $^ $(INCLUDES)
 
 bench_ntt.o: bench_ntt.cpp include/bench_ntt.hpp
@@ -90,16 +96,16 @@ aot_cpu:
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c utils.cpp -o utils.o $(INCLUDES)
 	@if lscpu | grep -q 'avx512'; then \
 		echo "Using avx512"; \
-		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(SYCLSGFLAGS) $(INCLUDES) $(DFLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx512" ff_p.cpp bench_rescue_prime.cpp rescue_prime.cpp tests/test_ntt.cpp bench_ntt.cpp ntt.cpp utils.o main.o; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(SYCLSGFLAGS) $(INCLUDES) $(DFLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx512" ff_p.cpp bench_rescue_prime.cpp rescue_prime.cpp tests/test_ntt.cpp bench_ntt.cpp ntt.cpp bench_merkle_tree.cpp merkle_tree.cpp utils.o main.o; \
 	elif lscpu | grep -q 'avx2'; then \
 		echo "Using avx2"; \
-		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(SYCLSGFLAGS) $(INCLUDES) $(DFLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx2" ff_p.cpp bench_rescue_prime.cpp rescue_prime.cpp tests/test_ntt.cpp bench_ntt.cpp ntt.cpp utils.o main.o; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(SYCLSGFLAGS) $(INCLUDES) $(DFLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx2" ff_p.cpp bench_rescue_prime.cpp rescue_prime.cpp tests/test_ntt.cpp bench_ntt.cpp ntt.cpp bench_merkle_tree.cpp merkle_tree.cpp utils.o main.o; \
 	elif lscpu | grep -q 'avx'; then \
 		echo "Using avx"; \
-		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(SYCLSGFLAGS) $(INCLUDES) $(DFLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx" ff_p.cpp bench_rescue_prime.cpp rescue_prime.cpp tests/test_ntt.cpp bench_ntt.cpp ntt.cpp utils.o main.o; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(SYCLSGFLAGS) $(INCLUDES) $(DFLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=avx" ff_p.cpp bench_rescue_prime.cpp rescue_prime.cpp tests/test_ntt.cpp bench_ntt.cpp ntt.cpp bench_merkle_tree.cpp merkle_tree.cpp utils.o main.o; \
 	elif lscpu | grep -q 'sse4.2'; then \
 		echo "Using sse4.2"; \
-		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(SYCLSGFLAGS) $(INCLUDES) $(DFLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=sse4.2" ff_p.cpp bench_rescue_prime.cpp rescue_prime.cpp tests/test_ntt.cpp bench_ntt.cpp ntt.cpp utils.o main.o; \
+		$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(SYCLSGFLAGS) $(INCLUDES) $(DFLAGS) -fsycl-targets=spir64_x86_64 -Xs "-march=sse4.2" ff_p.cpp bench_rescue_prime.cpp rescue_prime.cpp tests/test_ntt.cpp bench_ntt.cpp ntt.cpp bench_merkle_tree.cpp merkle_tree.cpp utils.o main.o; \
 	else \
 		echo "Can't AOT compile using avx, avx2, avx512 or sse4.2"; \
 	fi
@@ -107,13 +113,15 @@ aot_cpu:
 aot_gpu:
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c main.cpp -o main.o $(INCLUDES)
 	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(DFLAGS) -c utils.cpp -o utils.o $(INCLUDES)
-	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(SYCLSGFLAGS) $(INCLUDES) $(DFLAGS) -fsycl-targets=spir64_gen -Xs "-device 0x4905" ff_p.cpp bench_rescue_prime.cpp rescue_prime.cpp tests/test_ntt.cpp bench_ntt.cpp ntt.cpp utils.o main.o
+	$(CXX) $(CXXFLAGS) $(SYCLFLAGS) $(SYCLSGFLAGS) $(INCLUDES) $(DFLAGS) -fsycl-targets=spir64_gen -Xs "-device 0x4905" ff_p.cpp bench_rescue_prime.cpp rescue_prime.cpp tests/test_ntt.cpp bench_ntt.cpp ntt.cpp bench_merkle_tree.cpp merkle_tree.cpp utils.o main.o
 
 cuda:
 	$(CXX) $(CXXFLAGS) $(SYCLCUDAFLAGS) $(INCLUDES)  -c main.cpp -o main.o $(DFLAGS)
 	$(CXX) $(CXXFLAGS) $(SYCLCUDAFLAGS) $(INCLUDES)  -c utils.cpp -o utils.o
+	$(CXX) $(CXXFLAGS) $(SYCLCUDAFLAGS) $(INCLUDES)  -c bench_merkle_tree.cpp -o bench_merkle_tree.o
 	$(CXX) $(CXXFLAGS) $(SYCLCUDAFLAGS) $(INCLUDES)  -c bench_rescue_prime.cpp -o bench_rescue_prime.o
 	$(CXX) $(CXXFLAGS) $(SYCLCUDAFLAGS) $(INCLUDES)  -c bench_ntt.cpp -o bench_ntt.o
+	$(CXX) $(CXXFLAGS) $(SYCLCUDAFLAGS) $(INCLUDES)  -c merkle_tree.cpp -o merkle_tree.o
 	$(CXX) $(CXXFLAGS) $(SYCLCUDAFLAGS) $(INCLUDES)  -c ff_p.cpp -o ff_p.o
 	$(CXX) $(CXXFLAGS) $(SYCLCUDAFLAGS) $(INCLUDES)  -c ntt.cpp -o ntt.o
 	$(CXX) $(CXXFLAGS) $(SYCLCUDAFLAGS) $(INCLUDES)  -c rescue_prime.cpp -o rescue_prime.o

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ I run benchmark suite on both **Intel CPU/ GPU** and **Nvidia GPU**, keeping res
     - [(Inverse) Number Theoretic Transform on `F(2 ** 64 - 2 ** 32 + 1)`](benchmarks/cuda_ntt.md)
         - Cooley-Tukey (I)FFT
         - Six Step Algorithm (I)FFT
+    - [Merkel Tree Construction](benchmarks/cuda_merkle_tree.md)
 
 ## Tests
 

--- a/bench_merkle_tree.cpp
+++ b/bench_merkle_tree.cpp
@@ -1,0 +1,74 @@
+#include <bench_merkle_tree.hpp>
+#include <merkle_tree.hpp>
+#include <random>
+
+uint64_t
+benchmark_merklize(sycl::queue& q,
+                   const size_t leaf_count,
+                   const size_t wg_size)
+{
+  sycl::ulong* leaves_h = static_cast<sycl::ulong*>(
+    sycl::malloc_host(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+  sycl::ulong* leaves_d = static_cast<sycl::ulong*>(
+    sycl::malloc_device(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+
+  sycl::ulong* intermediates = static_cast<sycl::ulong*>(
+    sycl::malloc_device(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+
+  sycl::ulong16* mds_h = static_cast<sycl::ulong16*>(
+    sycl::malloc_host(sizeof(sycl::ulong16) * STATE_WIDTH, q));
+  sycl::ulong16* mds_d = static_cast<sycl::ulong16*>(
+    sycl::malloc_device(sizeof(sycl::ulong16) * STATE_WIDTH, q));
+
+  sycl::ulong16* ark1_h = static_cast<sycl::ulong16*>(
+    sycl::malloc_host(sizeof(sycl::ulong16) * NUM_ROUNDS, q));
+  sycl::ulong16* ark1_d = static_cast<sycl::ulong16*>(
+    sycl::malloc_device(sizeof(sycl::ulong16) * NUM_ROUNDS, q));
+
+  sycl::ulong16* ark2_h = static_cast<sycl::ulong16*>(
+    sycl::malloc_host(sizeof(sycl::ulong16) * NUM_ROUNDS, q));
+  sycl::ulong16* ark2_d = static_cast<sycl::ulong16*>(
+    sycl::malloc_device(sizeof(sycl::ulong16) * NUM_ROUNDS, q));
+
+  {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint64_t> dis(1ul, MOD);
+
+    for (uint64_t i = 0; i < leaf_count * DIGEST_SIZE; i++) {
+      *(leaves_h + i) = static_cast<sycl::ulong>(dis(gen));
+    }
+  }
+
+  prepare_mds(mds_h);
+  prepare_ark1(ark1_h);
+  prepare_ark2(ark2_h);
+
+  sycl::event evt_0 = q.memcpy(
+    leaves_d, leaves_h, sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE);
+  sycl::event evt_1 =
+    q.memcpy(mds_d, mds_h, sizeof(sycl::ulong16) * STATE_WIDTH);
+  sycl::event evt_2 =
+    q.memcpy(ark1_d, ark1_h, sizeof(sycl::ulong16) * NUM_ROUNDS);
+  sycl::event evt_3 =
+    q.memcpy(ark2_d, ark2_h, sizeof(sycl::ulong16) * NUM_ROUNDS);
+
+  // wait for host to device copies to complete !
+  q.wait();
+
+  // this itself does host synchronization
+  uint64_t ts = merklize(
+    q, leaves_d, intermediates, leaf_count, wg_size, mds_d, ark1_d, ark2_d);
+
+  sycl::free(leaves_h, q);
+  sycl::free(leaves_d, q);
+  sycl::free(intermediates, q);
+  sycl::free(mds_h, q);
+  sycl::free(ark1_h, q);
+  sycl::free(ark2_h, q);
+  sycl::free(mds_d, q);
+  sycl::free(ark1_d, q);
+  sycl::free(ark2_d, q);
+
+  return ts;
+}

--- a/bench_merkle_tree.cpp
+++ b/bench_merkle_tree.cpp
@@ -3,7 +3,7 @@
 #include <random>
 
 uint64_t
-benchmark_merklize(sycl::queue& q,
+benchmark_merklize_approach_1(sycl::queue& q,
                    const size_t leaf_count,
                    const size_t wg_size)
 {
@@ -57,7 +57,78 @@ benchmark_merklize(sycl::queue& q,
   q.wait();
 
   // this itself does host synchronization
-  uint64_t ts = merklize(
+  uint64_t ts = merklize_approach_1(
+    q, leaves_d, intermediates, leaf_count, wg_size, mds_d, ark1_d, ark2_d);
+
+  sycl::free(leaves_h, q);
+  sycl::free(leaves_d, q);
+  sycl::free(intermediates, q);
+  sycl::free(mds_h, q);
+  sycl::free(ark1_h, q);
+  sycl::free(ark2_h, q);
+  sycl::free(mds_d, q);
+  sycl::free(ark1_d, q);
+  sycl::free(ark2_d, q);
+
+  return ts;
+}
+
+uint64_t
+benchmark_merklize_approach_2(sycl::queue& q,
+                   const size_t leaf_count,
+                   const size_t wg_size)
+{
+  sycl::ulong* leaves_h = static_cast<sycl::ulong*>(
+    sycl::malloc_host(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+  sycl::ulong* leaves_d = static_cast<sycl::ulong*>(
+    sycl::malloc_device(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+
+  sycl::ulong* intermediates = static_cast<sycl::ulong*>(
+    sycl::malloc_device(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+
+  sycl::ulong16* mds_h = static_cast<sycl::ulong16*>(
+    sycl::malloc_host(sizeof(sycl::ulong16) * STATE_WIDTH, q));
+  sycl::ulong16* mds_d = static_cast<sycl::ulong16*>(
+    sycl::malloc_device(sizeof(sycl::ulong16) * STATE_WIDTH, q));
+
+  sycl::ulong16* ark1_h = static_cast<sycl::ulong16*>(
+    sycl::malloc_host(sizeof(sycl::ulong16) * NUM_ROUNDS, q));
+  sycl::ulong16* ark1_d = static_cast<sycl::ulong16*>(
+    sycl::malloc_device(sizeof(sycl::ulong16) * NUM_ROUNDS, q));
+
+  sycl::ulong16* ark2_h = static_cast<sycl::ulong16*>(
+    sycl::malloc_host(sizeof(sycl::ulong16) * NUM_ROUNDS, q));
+  sycl::ulong16* ark2_d = static_cast<sycl::ulong16*>(
+    sycl::malloc_device(sizeof(sycl::ulong16) * NUM_ROUNDS, q));
+
+  {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint64_t> dis(1ul, MOD);
+
+    for (uint64_t i = 0; i < leaf_count * DIGEST_SIZE; i++) {
+      *(leaves_h + i) = static_cast<sycl::ulong>(dis(gen));
+    }
+  }
+
+  prepare_mds(mds_h);
+  prepare_ark1(ark1_h);
+  prepare_ark2(ark2_h);
+
+  sycl::event evt_0 = q.memcpy(
+    leaves_d, leaves_h, sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE);
+  sycl::event evt_1 =
+    q.memcpy(mds_d, mds_h, sizeof(sycl::ulong16) * STATE_WIDTH);
+  sycl::event evt_2 =
+    q.memcpy(ark1_d, ark1_h, sizeof(sycl::ulong16) * NUM_ROUNDS);
+  sycl::event evt_3 =
+    q.memcpy(ark2_d, ark2_h, sizeof(sycl::ulong16) * NUM_ROUNDS);
+
+  // wait for host to device copies to complete !
+  q.wait();
+
+  // this itself does host synchronization
+  uint64_t ts = merklize_approach_2(
     q, leaves_d, intermediates, leaf_count, wg_size, mds_d, ark1_d, ark2_d);
 
   sycl::free(leaves_h, q);

--- a/benchmarks/cuda_merkle_tree.md
+++ b/benchmarks/cuda_merkle_tree.md
@@ -1,0 +1,31 @@
+## Benchmarking Merklization using Rescue Prime Hash on F(2 ** 64 - 2 ** 32 + 1) with CUDA Backend
+
+In benchmarking code, I construct all intermediate nodes of Binary Merkle Tree, where N -many leaves are provided. Each leaf is a Rescue Prime digest and Rescue Prime function `merge` is used for merging two children nodes & computing immediate parent node ( which is intermediate node, indeed ). Note, in all these case N must be power of 2. Each digest of Rescue Prime hash is 4 field elements ( i.e. 256 -bit ) wide. After Merklization (N - 1) -many intermediate nodes to be computed. 
+
+I've applied two approaches in writing Merklization routine. Their underlying assumptions are similar, it's just that how work is distributed or more specifically speaking which work-item is orchestrated to do what  is different. 
+
+> I plan to write a detailed description/ comparison of both of these approaches. [ **WIP** ]
+
+```bash
+DEVICE=gpu make cuda && ./run
+```
+
+```bash
+running on Tesla V100-SXM2-16GB
+
+Merklize ( approach 1 ) using Rescue Prime on F(2**64 - 2**32 + 1) elements 👇
+
+  leaves		          total
+    1048576		        155.599 ms
+    2097152		        288.474 ms
+    4194304		        545.014 ms
+    8388608		        1064.77 ms
+
+Merklize ( approach 2 ) using Rescue Prime on F(2**64 - 2**32 + 1) elements 👇
+
+  leaves		          total
+    1048576		        89.3281 ms
+    2097152		        162.115 ms
+    4194304		        306.274 ms
+    8388608		        593.398 ms
+```

--- a/include/bench_merkle_tree.hpp
+++ b/include/bench_merkle_tree.hpp
@@ -5,6 +5,14 @@
 //
 // Ensure SYCL queue has profiling enabled !
 uint64_t
-benchmark_merklize(sycl::queue& q,
-                   const size_t leaf_count,
-                   const size_t wg_size);
+benchmark_merklize_approach_1(sycl::queue& q,
+                              const size_t leaf_count,
+                              const size_t wg_size);
+
+// Returns sum of all kernel execution times in nanosecond
+//
+// Ensure SYCL queue has profiling enabled !
+uint64_t
+benchmark_merklize_approach_2(sycl::queue& q,
+                              const size_t leaf_count,
+                              const size_t wg_size);

--- a/include/bench_merkle_tree.hpp
+++ b/include/bench_merkle_tree.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <CL/sycl.hpp>
+
+// Returns exact time of kernel execution in nanosecond
+//
+// Ensure SYCL queue has profiling enabled !
+uint64_t
+benchmark_merklize(sycl::queue& q,
+                   const size_t leaf_count,
+                   const size_t wg_size);

--- a/include/merkle_tree.hpp
+++ b/include/merkle_tree.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include <cassert>
+#include <rescue_prime.hpp>
+
+// Given N -many leaves of Binary Merkle Tree computes all (N - 1) -many
+// intermediate nodes by using Rescue Prime `merge` function, which
+// merges two Rescue Prime digests into single of width 256 -bit
+//
+// N needs to be power of two
+//
+// Returns sum of all kernel execution times with nanosecond
+// level granularity
+uint64_t
+merklize(sycl::queue& q,
+         const sycl::ulong* leaves,
+         sycl::ulong* const intermediates,
+         const size_t leaf_count,
+         const size_t wg_size,
+         const sycl::ulong16* mds,
+         const sycl::ulong16* ark1,
+         const sycl::ulong16* ark2);

--- a/include/merkle_tree.hpp
+++ b/include/merkle_tree.hpp
@@ -11,11 +11,38 @@
 // Returns sum of all kernel execution times with nanosecond
 // level granularity
 uint64_t
-merklize(sycl::queue& q,
-         const sycl::ulong* leaves,
-         sycl::ulong* const intermediates,
-         const size_t leaf_count,
-         const size_t wg_size,
-         const sycl::ulong16* mds,
-         const sycl::ulong16* ark1,
-         const sycl::ulong16* ark2);
+merklize_approach_1(sycl::queue& q,
+                    const sycl::ulong* leaves,
+                    sycl::ulong* const intermediates,
+                    const size_t leaf_count,
+                    const size_t wg_size,
+                    const sycl::ulong16* mds,
+                    const sycl::ulong16* ark1,
+                    const sycl::ulong16* ark2);
+
+// Same as above routine, serves similar purpose, when
+// N -many leaves of binary merkle tree are provided, computes
+// all N-1 -many intermediates, while using Rescue Prime merge function
+// for merging two digests, which is equivalent to computing parent node
+// from two children
+//
+// N -needs to be power of 2
+//
+// Check those assertions, I've written in implementation of this routine
+// which are my assumptions, feel free to tinker with them !
+//
+// Returns total time spent on computing merkle tree intermediate nodes
+// with nanosecond level granularity
+//
+// Have taken major motivation from
+// https://github.com/itzmeanjan/vectorized-rescue-prime/blob/c48b8555e07eb9557a20383cc9f3a4aeec834317/rescue_prime.c#L153-L164
+// where I wrote similar routine using OpenCL
+uint64_t
+merklize_approach_2(sycl::queue& q,
+                    const sycl::ulong* leaves,
+                    sycl::ulong* const intermediates,
+                    const size_t leaf_count,
+                    const size_t wg_size,
+                    const sycl::ulong16* mds,
+                    const sycl::ulong16* ark1,
+                    const sycl::ulong16* ark2);

--- a/include/test_merkle_tree.hpp
+++ b/include/test_merkle_tree.hpp
@@ -1,0 +1,8 @@
+#pragma once
+#include <merkle_tree.hpp>
+#include <random>
+#include <cassert>
+
+// Test that merkle tree construction kernel is working as expected !
+void
+test_merklize(sycl::queue& q);

--- a/main.cpp
+++ b/main.cpp
@@ -1,3 +1,4 @@
+#include "bench_merkle_tree.hpp"
 #include "bench_ntt.hpp"
 #include "bench_rescue_prime.hpp"
 #include <iomanip>
@@ -75,6 +76,20 @@ main(int argc, char** argv)
               << (double)tm / (double)(dim * dim * 1) << " ns"
               << "\t\t" << std::setw(15) << std::right
               << 1e9 / ((double)tm / (double)(dim * dim * 1)) << std::endl;
+  }
+
+  std::cout
+    << "\nMerklize using Rescue Prime on F(2**64 - 2**32 + 1) elements 👇\n"
+    << std::endl;
+  std::cout << std::setw(11) << "dimension"
+            << "\t\t" << std::setw(15) << "total" << std::endl;
+
+  for (uint dim = (1ul << 20); dim <= (1ul << 23); dim <<= 1) {
+    // time in nanoseconds --- beware !
+    uint64_t tm = benchmark_merklize(q, dim, 1ul << 6);
+
+    std::cout << std::setw(11) << std::right << dim << "\t\t" << std::setw(15)
+              << std::right << tm * 1e-6 << " ms" << std::endl;
   }
 
   std::cout << "\nForward NTT on F(2**64 - 2**32 + 1) elements 👇\n"

--- a/main.cpp
+++ b/main.cpp
@@ -86,7 +86,7 @@ main(int argc, char** argv)
 
   for (uint dim = (1ul << 20); dim <= (1ul << 23); dim <<= 1) {
     // time in nanoseconds --- beware !
-    uint64_t tm = benchmark_merklize(q, dim, 1ul << 6);
+    uint64_t tm = benchmark_merklize(q, dim, 1ul << 5);
 
     std::cout << std::setw(11) << std::right << dim << "\t\t" << std::setw(15)
               << std::right << tm * 1e-6 << " ms" << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -78,15 +78,29 @@ main(int argc, char** argv)
               << 1e9 / ((double)tm / (double)(dim * dim * 1)) << std::endl;
   }
 
-  std::cout
-    << "\nMerklize using Rescue Prime on F(2**64 - 2**32 + 1) elements 👇\n"
-    << std::endl;
+  std::cout << "\nMerklize ( approach 1 ) using Rescue Prime on F(2**64 - "
+               "2**32 + 1) elements 👇\n"
+            << std::endl;
   std::cout << std::setw(11) << "dimension"
             << "\t\t" << std::setw(15) << "total" << std::endl;
 
   for (uint dim = (1ul << 20); dim <= (1ul << 23); dim <<= 1) {
     // time in nanoseconds --- beware !
-    uint64_t tm = benchmark_merklize(q, dim, 1ul << 5);
+    uint64_t tm = benchmark_merklize_approach_1(q, dim, 1ul << 5);
+
+    std::cout << std::setw(11) << std::right << dim << "\t\t" << std::setw(15)
+              << std::right << tm * 1e-6 << " ms" << std::endl;
+  }
+
+  std::cout << "\nMerklize ( approach 2 ) using Rescue Prime on F(2**64 - "
+               "2**32 + 1) elements 👇\n"
+            << std::endl;
+  std::cout << std::setw(11) << "dimension"
+            << "\t\t" << std::setw(15) << "total" << std::endl;
+
+  for (uint dim = (1ul << 20); dim <= (1ul << 23); dim <<= 1) {
+    // time in nanoseconds --- beware !
+    uint64_t tm = benchmark_merklize_approach_2(q, dim, 1ul << 5);
 
     std::cout << std::setw(11) << std::right << dim << "\t\t" << std::setw(15)
               << std::right << tm * 1e-6 << " ms" << std::endl;

--- a/main.cpp
+++ b/main.cpp
@@ -81,7 +81,7 @@ main(int argc, char** argv)
   std::cout << "\nMerklize ( approach 1 ) using Rescue Prime on F(2**64 - "
                "2**32 + 1) elements 👇\n"
             << std::endl;
-  std::cout << std::setw(11) << "dimension"
+  std::cout << std::setw(11) << "leaves"
             << "\t\t" << std::setw(15) << "total" << std::endl;
 
   for (uint dim = (1ul << 20); dim <= (1ul << 23); dim <<= 1) {
@@ -95,7 +95,7 @@ main(int argc, char** argv)
   std::cout << "\nMerklize ( approach 2 ) using Rescue Prime on F(2**64 - "
                "2**32 + 1) elements 👇\n"
             << std::endl;
-  std::cout << std::setw(11) << "dimension"
+  std::cout << std::setw(11) << "leaves"
             << "\t\t" << std::setw(15) << "total" << std::endl;
 
   for (uint dim = (1ul << 20); dim <= (1ul << 23); dim <<= 1) {

--- a/merkle_tree.cpp
+++ b/merkle_tree.cpp
@@ -1,0 +1,123 @@
+#include <merkle_tree.hpp>
+
+uint64_t
+merklize(sycl::queue& q,
+         const sycl::ulong* leaves,
+         sycl::ulong* const intermediates,
+         const size_t leaf_count,
+         const size_t wg_size,
+         const sycl::ulong16* mds,
+         const sycl::ulong16* ark1,
+         const sycl::ulong16* ark2)
+{
+  // ensure only working with powers of 2 -many leaves
+  assert(leaf_count & (leaf_count) == 0);
+  assert(wg_size <= (leaf_count >> 2));
+
+  // so that only last half of tree is touched, where
+  // intermediate nodes just above leaves are stored
+  const size_t output_offset = leaf_count >> 1;
+
+  sycl::event evt_0 = q.submit([&](sycl::handler& h) {
+    h.parallel_for<class kernelMerklizeRescuePrimePhase0>(
+      sycl::nd_range<1>{ sycl::range<1>{ leaf_count >> 1 },
+                         sycl::range<1>{ wg_size } },
+      [=](sycl::nd_item<1> it) {
+        const size_t idx = it.get_global_linear_id();
+
+        merge(leaves + (idx >> 1) * (DIGEST_SIZE >> 1),
+              intermediates + output_offset + idx * DIGEST_SIZE,
+              mds,
+              ark1,
+              ark2);
+      });
+  });
+
+  const size_t log_wg_size =
+    static_cast<size_t>(sycl::log2<float>(static_cast<float>(wg_size)));
+  const size_t rounds =
+    (leaf_count >> 2) == wg_size
+      ? 1
+      : (leaf_count >> 3) == wg_size
+          ? (static_cast<size_t>(sycl::log2<float>(
+               static_cast<float>((leaf_count >> 2) >> log_wg_size))) +
+             1)
+          : static_cast<size_t>(sycl::log2<float>(
+              static_cast<float>((leaf_count >> 2) >> log_wg_size)));
+
+  std::vector<sycl::event> evts;
+  evts.reserve(rounds);
+
+  size_t offset = (leaf_count >> 2);
+  for (size_t r = 0; r < rounds; r++) {
+    sycl::event evt = q.submit([&](sycl::handler& h) {
+      if (r == 0) {
+        h.depends_on(evt_0);
+      } else {
+        h.depends_on(evts.at(r - 1));
+      }
+
+      h.parallel_for<class kernelMerklizeRescuePrimePhase1>(
+        sycl::nd_range<1>{
+          sycl::range<1>{ offset },
+          sycl::range<1>{ offset < wg_size ? offset : wg_size } },
+        [=](sycl::nd_item<1> it) {
+          const size_t idx = it.get_global_linear_id();
+
+          merge(intermediates + (offset >> 1) + (idx >> 1) * (DIGEST_SIZE >> 1),
+                intermediates + offset + idx * DIGEST_SIZE,
+                mds,
+                ark1,
+                ark2);
+
+          size_t round = 1;
+          const size_t loc_size = it.get_local_range(0);
+          sycl::group<1> grp = it.get_group();
+
+          sycl::group_barrier(grp, sycl::memory_scope_work_group);
+
+          while ((1 << (round - 1)) < loc_size) {
+            if (idx % (1 << round) == 0) {
+              merge(intermediates + (offset >> (round - 1)) +
+                      (idx >> (round - 1)) * (DIGEST_SIZE >> 1),
+                    intermediates + (offset >> round) +
+                      (idx >> round) * DIGEST_SIZE,
+                    mds,
+                    ark1,
+                    ark2);
+            }
+
+            sycl::group_barrier(grp, sycl::memory_scope_work_group);
+            round++;
+          }
+        });
+    });
+
+    evts.push_back(evt);
+    offset >>= (log_wg_size + 1);
+    offset = offset == 0 ? 1 : offset;
+  }
+
+  evts.at(rounds - 1).wait();
+
+  // calculate sum of dispatched kernel execution times
+  uint64_t ts = 0;
+
+  uint64_t start =
+    evt_0.get_profiling_info<sycl::info::event_profiling::command_start>();
+  uint64_t end =
+    evt_0.get_profiling_info<sycl::info::event_profiling::command_end>();
+
+  ts += (end - start);
+
+  for (sycl::event evt : evts) {
+    uint64_t start =
+      evt.get_profiling_info<sycl::info::event_profiling::command_start>();
+    uint64_t end =
+      evt.get_profiling_info<sycl::info::event_profiling::command_end>();
+
+    ts += (end - start);
+  }
+
+  return ts;
+}

--- a/merkle_tree.cpp
+++ b/merkle_tree.cpp
@@ -1,14 +1,14 @@
 #include <merkle_tree.hpp>
 
 uint64_t
-merklize(sycl::queue& q,
-         const sycl::ulong* leaves,
-         sycl::ulong* const intermediates,
-         const size_t leaf_count,
-         const size_t wg_size,
-         const sycl::ulong16* mds,
-         const sycl::ulong16* ark1,
-         const sycl::ulong16* ark2)
+merklize_approach_1(sycl::queue& q,
+                    const sycl::ulong* leaves,
+                    sycl::ulong* const intermediates,
+                    const size_t leaf_count,
+                    const size_t wg_size,
+                    const sycl::ulong16* mds,
+                    const sycl::ulong16* ark1,
+                    const sycl::ulong16* ark2)
 {
   // ensure only working with powers of 2 -many leaves
   assert((leaf_count & (leaf_count - 1)) == 0);
@@ -19,7 +19,7 @@ merklize(sycl::queue& q,
   const size_t output_offset = leaf_count >> 1;
 
   sycl::event evt_0 = q.submit([&](sycl::handler& h) {
-    h.parallel_for<class kernelMerklizeRescuePrimePhase0>(
+    h.parallel_for<class kernelMerklizeRescuePrimeApproach0Phase0>(
       sycl::nd_range<1>{ sycl::range<1>{ leaf_count >> 1 },
                          sycl::range<1>{ wg_size } },
       [=](sycl::nd_item<1> it) {
@@ -57,7 +57,7 @@ merklize(sycl::queue& q,
         h.depends_on(evts.at(r - 1));
       }
 
-      h.parallel_for<class kernelMerklizeRescuePrimePhase1>(
+      h.parallel_for<class kernelMerklizeRescuePrimeApproach0Phase1>(
         sycl::nd_range<1>{
           sycl::range<1>{ offset },
           sycl::range<1>{ offset < wg_size ? offset : wg_size } },
@@ -97,6 +97,107 @@ merklize(sycl::queue& q,
     evts.push_back(evt);
     offset >>= (log_wg_size + 1);
     offset = offset == 0 ? 1 : offset;
+  }
+
+  evts.at(rounds - 1).wait();
+
+  // calculate sum of dispatched kernel execution times
+  uint64_t ts = 0;
+
+  uint64_t start =
+    evt_0.get_profiling_info<sycl::info::event_profiling::command_start>();
+  uint64_t end =
+    evt_0.get_profiling_info<sycl::info::event_profiling::command_end>();
+
+  ts += (end - start);
+
+  for (sycl::event evt : evts) {
+    uint64_t start =
+      evt.get_profiling_info<sycl::info::event_profiling::command_start>();
+    uint64_t end =
+      evt.get_profiling_info<sycl::info::event_profiling::command_end>();
+
+    ts += (end - start);
+  }
+
+  return ts;
+}
+
+uint64_t
+merklize_approach_2(sycl::queue& q,
+                    const sycl::ulong* leaves,
+                    sycl::ulong* const intermediates,
+                    const size_t leaf_count,
+                    const size_t wg_size,
+                    const sycl::ulong16* mds,
+                    const sycl::ulong16* ark1,
+                    const sycl::ulong16* ark2)
+{
+  // ensure only working with powers of 2 -many leaves
+  assert((leaf_count & (leaf_count - 1)) == 0);
+  // checking that requested work group size for first
+  // phase of kernel dispatch is valid
+  //
+  // for next rounds of kernel dispatches, work group
+  // size will be adapted when required !
+  assert(wg_size <= (leaf_count >> 1));
+
+  const size_t output_offset = leaf_count >> 1;
+
+  // this is first phase of kernel dispatch, where I compute
+  // ( in parallel ) all intermediate nodes just above leaves of tree
+  sycl::event evt_0 = q.submit([&](sycl::handler& h) {
+    h.parallel_for<class kernelMerklizeRescuePrimeApproach1Phase0>(
+      sycl::nd_range<1>{ sycl::range<1>{ output_offset },
+                         sycl::range<1>{ wg_size } },
+      [=](sycl::nd_item<1> it) {
+        const size_t idx = it.get_global_linear_id();
+
+        merge(leaves + idx * (DIGEST_SIZE >> 1),
+              intermediates + (output_offset + idx) * DIGEST_SIZE,
+              mds,
+              ark1,
+              ark2);
+      });
+  });
+
+  // for computing all remaining intermediate nodes, we'll need to
+  // dispatch `rounds` -many kernels, where each round is data dependent
+  // on just previous one
+  const size_t rounds =
+    static_cast<size_t>(sycl::log2(static_cast<double>(leaf_count >> 1)));
+
+  std::vector<sycl::event> evts;
+  evts.reserve(rounds);
+
+  for (size_t r = 0; r < rounds; r++) {
+    sycl::event evt = q.submit([&](sycl::handler& h) {
+      if (r == 0) {
+        h.depends_on(evt_0);
+      } else {
+        h.depends_on(evts.at(r - 1));
+      }
+
+      // these many intermediate nodes to be computed during this
+      // kernel dispatch round
+      const size_t offset = leaf_count >> (r + 2);
+
+      h.parallel_for<class kernelMerklizeRescuePrimeApproach1Phase1>(
+        sycl::nd_range<1>{
+          sycl::range<1>{ offset },
+          sycl::range<1>{ offset < wg_size ? offset : wg_size } },
+        [=](sycl::nd_item<1> it) {
+          const size_t idx = it.get_global_linear_id();
+
+          merge(intermediates + (offset << 1) * DIGEST_SIZE +
+                  idx * (DIGEST_SIZE >> 1),
+                intermediates + (offset + idx) * DIGEST_SIZE,
+                mds,
+                ark1,
+                ark2);
+        });
+    });
+    evts.push_back(evt);
   }
 
   evts.at(rounds - 1).wait();

--- a/merkle_tree.cpp
+++ b/merkle_tree.cpp
@@ -11,7 +11,7 @@ merklize(sycl::queue& q,
          const sycl::ulong16* ark2)
 {
   // ensure only working with powers of 2 -many leaves
-  assert(leaf_count & (leaf_count) == 0);
+  assert((leaf_count & (leaf_count - 1)) == 0);
   assert(wg_size <= (leaf_count >> 2));
 
   // so that only last half of tree is touched, where

--- a/merkle_tree.cpp
+++ b/merkle_tree.cpp
@@ -25,8 +25,8 @@ merklize(sycl::queue& q,
       [=](sycl::nd_item<1> it) {
         const size_t idx = it.get_global_linear_id();
 
-        merge(leaves + (idx >> 1) * (DIGEST_SIZE >> 1),
-              intermediates + output_offset + idx * DIGEST_SIZE,
+        merge(leaves + idx * (DIGEST_SIZE >> 1),
+              intermediates + (output_offset + idx) * DIGEST_SIZE,
               mds,
               ark1,
               ark2);
@@ -64,8 +64,9 @@ merklize(sycl::queue& q,
         [=](sycl::nd_item<1> it) {
           const size_t idx = it.get_global_linear_id();
 
-          merge(intermediates + (offset >> 1) + (idx >> 1) * (DIGEST_SIZE >> 1),
-                intermediates + offset + idx * DIGEST_SIZE,
+          merge(intermediates + (offset << 1) * DIGEST_SIZE +
+                  idx * (DIGEST_SIZE >> 1),
+                intermediates + (offset + idx) * DIGEST_SIZE,
                 mds,
                 ark1,
                 ark2);
@@ -78,10 +79,10 @@ merklize(sycl::queue& q,
 
           while ((1 << (round - 1)) < loc_size) {
             if (idx % (1 << round) == 0) {
-              merge(intermediates + (offset >> (round - 1)) +
-                      (idx >> (round - 1)) * (DIGEST_SIZE >> 1),
-                    intermediates + (offset >> round) +
-                      (idx >> round) * DIGEST_SIZE,
+              merge(intermediates + (offset >> (round - 1)) * DIGEST_SIZE +
+                      (idx >> round) * (DIGEST_SIZE >> 1),
+                    intermediates +
+                      ((offset >> round) + (idx >> round)) * DIGEST_SIZE,
                     mds,
                     ark1,
                     ark2);

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,4 +1,5 @@
 #include "test.hpp"
+#include "test_merkle_tree.hpp"
 #include "test_ntt.hpp"
 #include "test_rescue_prime.hpp"
 
@@ -16,7 +17,7 @@ main(int argc, char** argv)
 #else
   device d{ default_selector{} };
 #endif
-  queue q{ d };
+  queue q{ d, { sycl::property::queue::enable_profiling() } };
 
   std::cout << "running on " << d.get_info<info::device::name>() << "\n"
             << std::endl;
@@ -37,6 +38,9 @@ main(int argc, char** argv)
   test_inv_sbox(q);
   test_permutation(q);
   std::cout << "✅ passed rescue prime tests" << std::endl;
+
+  test_merklize(q);
+  std::cout << "✅ passed merkle tree tests" << std::endl;
 
   check_ntt_correctness(q, 1 << 10, 1 << 6);
   std::cout << "✅ passed NTT correctness test" << std::endl;

--- a/tests/test_merkle_tree.cpp
+++ b/tests/test_merkle_tree.cpp
@@ -38,111 +38,30 @@ test_merklize(sycl::queue& q)
   prepare_ark1(ark1);
   prepare_ark2(ark2);
 
+  // following two kernel dispatches will compute same merkle tree ( i.e. all
+  // intermediate nodes ) and finally root of two computed trees will be checked
+  // against each other
+
   // host sychronization in function itself !
-  merklize(q, leaves, intermediates_a, leaf_count, 2, mds, ark1, ark2);
+  merklize_approach_1(
+    q, leaves, intermediates_a, leaf_count, 4, mds, ark1, ark2);
 
-  // following block manually computes merkle root
-  // for asserting result produced by original merklization kernel
-  {
-    const size_t output_offset = leaf_count >> 1;
+  // host sychronization in function itself !
+  merklize_approach_2(
+    q, leaves, intermediates_b, leaf_count, 8, mds, ark1, ark2);
 
-    sycl::event evt_0 = q.submit([&](sycl::handler& h) {
-      h.parallel_for<class kernelMerklizeRescuePrimePhase0Test>(
-        sycl::nd_range<1>{ sycl::range<1>{ output_offset },
-                           sycl::range<1>{ output_offset } },
-        [=](sycl::nd_item<1> it) {
-          const size_t idx = it.get_global_linear_id();
-
-          merge(leaves + idx * (DIGEST_SIZE >> 1),
-                intermediates_b + (output_offset + idx) * DIGEST_SIZE,
-                mds,
-                ark1,
-                ark2);
-        });
-    });
-
-    const size_t rounds =
-      static_cast<size_t>(sycl::log2(static_cast<double>(leaf_count >> 1)));
-
-    std::vector<sycl::event> evts;
-    evts.reserve(rounds);
-
-    for (size_t r = 0; r < rounds; r++) {
-      sycl::event evt = q.submit([&](sycl::handler& h) {
-        if (r == 0) {
-          h.depends_on(evt_0);
-        } else {
-          h.depends_on(evts.at(r - 1));
-        }
-
-        const size_t offset = leaf_count >> (r + 2);
-
-        h.parallel_for<class kernelMerklizeRescuePrimePhase1Test>(
-          sycl::nd_range<1>{ sycl::range<1>{ offset },
-                             sycl::range<1>{ offset } },
-          [=](sycl::nd_item<1> it) {
-            const size_t idx = it.get_global_linear_id();
-
-            merge(intermediates_b + (offset << 1) * DIGEST_SIZE +
-                    idx * (DIGEST_SIZE >> 1),
-                  intermediates_b + (offset + idx) * DIGEST_SIZE,
-                  mds,
-                  ark1,
-                  ark2);
-          });
-      });
-      evts.push_back(evt);
-    }
-
-    evts.at(rounds - 1).wait();
-
-    // sycl::event evt_1 = q.submit([&](sycl::handler& h) {
-    //   h.depends_on(evt_0);
-    //   h.single_task([=]() {
-    //     for (size_t idx = 0; idx < (leaf_count >> 2); idx++) {
-    //       merge(intermediates_b + (leaf_count >> 1) * DIGEST_SIZE +
-    //               idx * (DIGEST_SIZE >> 1),
-    //             intermediates_b + ((leaf_count >> 2) + idx) * DIGEST_SIZE,
-    //             mds,
-    //             ark1,
-    //             ark2);
-    //     }
-
-    //     for (size_t idx = 0; idx < (leaf_count >> 3); idx++) {
-    //       merge(intermediates_b + (leaf_count >> 2) * DIGEST_SIZE +
-    //               idx * (DIGEST_SIZE >> 1),
-    //             intermediates_b + ((leaf_count >> 3) + idx) * DIGEST_SIZE,
-    //             mds,
-    //             ark1,
-    //             ark2);
-    //     }
-
-    //     for (size_t idx = 0; idx < (leaf_count >> 4); idx++) {
-    //       merge(intermediates_b + (leaf_count >> 3) * DIGEST_SIZE +
-    //               idx * (DIGEST_SIZE >> 1),
-    //             intermediates_b + ((leaf_count >> 4) + idx) * DIGEST_SIZE,
-    //             mds,
-    //             ark1,
-    //             ark2);
-    //     }
-    //   });
-    // });
-
-    // evt_1.wait();
-  }
-
-  // asserting that first digest in interemediate node holder
-  // memory allocation is never touched !
+  // asserting that first digest ( which spans 256 -bit ) in intermediate
+  // node holder memory allocation is never touched !
   //
   // four consequtive memory locations are checked because
-  // each rescue prime digest has width of 256 -bit which is
+  // each rescue prime digest has width of 256 -bit i.e.
   // 4 field elements wide
   assert(*(intermediates_a + 0) == 0);
   assert(*(intermediates_a + 1) == 0);
   assert(*(intermediates_a + 2) == 0);
   assert(*(intermediates_a + 3) == 0);
 
-  // same as above, this done just to ensure that assertion kernel
+  // same as above, this is done just to ensure that assertion kernel
   // never touches first four field elements, because it's never
   // desired/ required to be touched
   assert(*(intermediates_b + 0) == 0);
@@ -150,9 +69,8 @@ test_merklize(sycl::queue& q)
   assert(*(intermediates_b + 2) == 0);
   assert(*(intermediates_b + 3) == 0);
 
-  // check that root of merkle tree matches when computed
-  // using actual kernel ( which is being tested ) with
-  // manually computed intermediates ( hierarchically )
+  // asserting root of merkle tree, where each computed by two different
+  // kernels
   assert(*(intermediates_a + 4) == *(intermediates_b + 4));
   assert(*(intermediates_a + 5) == *(intermediates_b + 5));
   assert(*(intermediates_a + 6) == *(intermediates_b + 6));

--- a/tests/test_merkle_tree.cpp
+++ b/tests/test_merkle_tree.cpp
@@ -1,0 +1,109 @@
+#include <test_merkle_tree.hpp>
+
+void
+test_merklize(sycl::queue& q)
+{
+  const size_t leaf_count = 16;
+
+  sycl::ulong* leaves = static_cast<sycl::ulong*>(
+    sycl::malloc_shared(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+  sycl::ulong* intermediates_a = static_cast<sycl::ulong*>(
+    sycl::malloc_shared(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+  sycl::ulong* intermediates_b = static_cast<sycl::ulong*>(
+    sycl::malloc_shared(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+  sycl::ulong16* mds = static_cast<sycl::ulong16*>(
+    sycl::malloc_shared(sizeof(sycl::ulong16) * STATE_WIDTH, q));
+  sycl::ulong16* ark1 = static_cast<sycl::ulong16*>(
+    sycl::malloc_shared(sizeof(sycl::ulong16) * NUM_ROUNDS, q));
+  sycl::ulong16* ark2 = static_cast<sycl::ulong16*>(
+    sycl::malloc_shared(sizeof(sycl::ulong16) * NUM_ROUNDS, q));
+
+  {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint64_t> dis(1ul, MOD);
+
+    for (uint64_t i = 0; i < leaf_count * DIGEST_SIZE; i++) {
+      *(leaves + i) = static_cast<sycl::ulong>(dis(gen));
+    }
+  }
+
+  // just to ensure that very first digest cell is never touched,
+  // it should be zeroed, as being set here !
+  q.memset(intermediates_a, 0, sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE);
+  q.memset(intermediates_b, 0, sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE);
+  q.wait();
+
+  prepare_mds(mds);
+  prepare_ark1(ark1);
+  prepare_ark2(ark2);
+
+  // host sychronization in function itself !
+  merklize(q, leaves, intermediates_a, leaf_count, 2, mds, ark1, ark2);
+
+  // manually compute merkle root !
+  q.single_task([=]() {
+     for (size_t idx = 0; idx < (leaf_count >> 1); idx++) {
+       merge(leaves + idx * (DIGEST_SIZE >> 1),
+             intermediates_b + ((leaf_count >> 1) + idx) * DIGEST_SIZE,
+             mds,
+             ark1,
+             ark2);
+     }
+
+     for (size_t idx = 0; idx < (leaf_count >> 2); idx++) {
+       merge(intermediates_b + (leaf_count >> 1) * DIGEST_SIZE +
+               idx * (DIGEST_SIZE >> 1),
+             intermediates_b + ((leaf_count >> 2) + idx) * DIGEST_SIZE,
+             mds,
+             ark1,
+             ark2);
+     }
+
+     for (size_t idx = 0; idx < (leaf_count >> 3); idx++) {
+       merge(intermediates_b + (leaf_count >> 2) * DIGEST_SIZE +
+               idx * (DIGEST_SIZE >> 1),
+             intermediates_b + ((leaf_count >> 3) + idx) * DIGEST_SIZE,
+             mds,
+             ark1,
+             ark2);
+     }
+
+     for (size_t idx = 0; idx < (leaf_count >> 4); idx++) {
+       merge(intermediates_b + (leaf_count >> 3) * DIGEST_SIZE +
+               idx * (DIGEST_SIZE >> 1),
+             intermediates_b + ((leaf_count >> 4) + idx) * DIGEST_SIZE,
+             mds,
+             ark1,
+             ark2);
+     }
+   })
+    .wait();
+
+  // asserting that first digest in interemediate node holding
+  // allocation is never touched !
+  //
+  // four consequtive memory locations are checked because
+  // each rescue prime digest has width of 256 -bit which is
+  // 4 field elements wide
+  assert(*(intermediates_a + 0) == 0);
+  assert(*(intermediates_a + 1) == 0);
+  assert(*(intermediates_a + 2) == 0);
+  assert(*(intermediates_a + 3) == 0);
+
+  // check that root of merkle tree matches when computed
+  // using actual kernel ( which is being tested ) with
+  // manually computed intermediates ( hierarchically )
+  assert(*(intermediates_a + 4) == *(intermediates_b + 4));
+  assert(*(intermediates_a + 5) == *(intermediates_b + 5));
+  assert(*(intermediates_a + 6) == *(intermediates_b + 6));
+  assert(*(intermediates_a + 7) == *(intermediates_b + 7));
+
+  // deallocate all memory resources
+  sycl::free(leaves, q);
+  sycl::free(intermediates_a, q);
+  sycl::free(intermediates_b, q);
+  sycl::free(mds, q);
+  sycl::free(ark1, q);
+  sycl::free(ark2, q);
+}


### PR DESCRIPTION
This PR implements routines for parallelizing computation of intermediate nodes of fully balanced Binary Merkle Tree, while taking some inspiration from [here](https://github.com/itzmeanjan/vectorized-rescue-prime/blob/77e371ef2fb11ba7d7369005a60a0888393729f0/rescue_prime.c#L153-L164), which I wrote in OpenCL, sometime ago. 

Now I've written Merkle Tree kernel dispatching/ orchestration logic in two different ways and here are respective benchmark results when I compiled using [Intel's SYCL compiler](https://intel.github.io/llvm-docs/GetStartedGuide.html) using CUDA backend on Nvidia Tesla V100.

 Leaf Count | Approach 1 | Approach 2
--- | --- | ---
1048576 | 180.584 ms | 89.2852 ms
2097152 | 296.861 ms | 162.189 ms
4194304 | 545.38 ms | 306.154 ms
8388608 | 1065.68 ms | 593.262 ms

> Note approach 2 is nothing but SYCL translation of OpenCL kernel over [here](https://github.com/itzmeanjan/vectorized-rescue-prime/blob/c48b8555e07eb9557a20383cc9f3a4aeec834317/rescue_prime.c#L153-L164)

> You'll be probably interested in looking at [this](https://github.com/itzmeanjan/vectorized-rescue-prime/tree/77e371ef2fb11ba7d7369005a60a0888393729f0#nvidia-tesla-v100-gpu-with-opencl) benchmark obtained on same GPU, when aforementioned approach 2 was written in OpenCL. 

I plan to do deeper analysis of both of these techniques. 