### PR TITLE
Improved Merklization using Local Scratch Pad Memory

### DIFF
--- a/bench_merkle_tree.cpp
+++ b/bench_merkle_tree.cpp
@@ -143,3 +143,74 @@ benchmark_merklize_approach_2(sycl::queue& q,
 
   return ts;
 }
+
+uint64_t
+benchmark_merklize_approach_3(sycl::queue& q,
+                              const size_t leaf_count,
+                              const size_t wg_size)
+{
+  sycl::ulong* leaves_h = static_cast<sycl::ulong*>(
+    sycl::malloc_host(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+  sycl::ulong* leaves_d = static_cast<sycl::ulong*>(
+    sycl::malloc_device(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+
+  sycl::ulong* intermediates = static_cast<sycl::ulong*>(
+    sycl::malloc_device(sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE, q));
+
+  sycl::ulong4* mds_h = static_cast<sycl::ulong4*>(
+    sycl::malloc_host(sizeof(sycl::ulong4) * STATE_WIDTH * 3, q));
+  sycl::ulong4* mds_d = static_cast<sycl::ulong4*>(
+    sycl::malloc_device(sizeof(sycl::ulong4) * STATE_WIDTH * 3, q));
+
+  sycl::ulong4* ark1_h = static_cast<sycl::ulong4*>(
+    sycl::malloc_host(sizeof(sycl::ulong4) * NUM_ROUNDS * 3, q));
+  sycl::ulong4* ark1_d = static_cast<sycl::ulong4*>(
+    sycl::malloc_device(sizeof(sycl::ulong4) * NUM_ROUNDS * 3, q));
+
+  sycl::ulong4* ark2_h = static_cast<sycl::ulong4*>(
+    sycl::malloc_host(sizeof(sycl::ulong4) * NUM_ROUNDS * 3, q));
+  sycl::ulong4* ark2_d = static_cast<sycl::ulong4*>(
+    sycl::malloc_device(sizeof(sycl::ulong4) * NUM_ROUNDS * 3, q));
+
+  {
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint64_t> dis(1ul, MOD);
+
+    for (uint64_t i = 0; i < leaf_count * DIGEST_SIZE; i++) {
+      *(leaves_h + i) = static_cast<sycl::ulong>(dis(gen));
+    }
+  }
+
+  prepare_mds(mds_h);
+  prepare_ark1(ark1_h);
+  prepare_ark2(ark2_h);
+
+  sycl::event evt_0 = q.memcpy(
+    leaves_d, leaves_h, sizeof(sycl::ulong) * leaf_count * DIGEST_SIZE);
+  sycl::event evt_1 =
+    q.memcpy(mds_d, mds_h, sizeof(sycl::ulong4) * STATE_WIDTH * 3);
+  sycl::event evt_2 =
+    q.memcpy(ark1_d, ark1_h, sizeof(sycl::ulong4) * NUM_ROUNDS * 3);
+  sycl::event evt_3 =
+    q.memcpy(ark2_d, ark2_h, sizeof(sycl::ulong4) * NUM_ROUNDS * 3);
+
+  // wait for host to device copies to complete !
+  q.wait();
+
+  // this itself does host synchronization
+  uint64_t ts = merklize_approach_3(
+    q, leaves_d, intermediates, leaf_count, wg_size, mds_d, ark1_d, ark2_d);
+
+  sycl::free(leaves_h, q);
+  sycl::free(leaves_d, q);
+  sycl::free(intermediates, q);
+  sycl::free(mds_h, q);
+  sycl::free(ark1_h, q);
+  sycl::free(ark2_h, q);
+  sycl::free(mds_d, q);
+  sycl::free(ark1_d, q);
+  sycl::free(ark2_d, q);
+
+  return ts;
+}

--- a/bench_ntt.cpp
+++ b/bench_ntt.cpp
@@ -22,7 +22,7 @@ benchmark_forward_transform(sycl::queue& q,
   std::free(vec_src);
   std::free(vec_fwd);
 
-  return std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+  return std::chrono::duration_cast<std::chrono::microseconds>(end - start)
     .count();
 }
 
@@ -48,7 +48,7 @@ benchmark_inverse_transform(sycl::queue& q,
   std::free(vec_src);
   std::free(vec_inv);
 
-  return std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
+  return std::chrono::duration_cast<std::chrono::microseconds>(end - start)
     .count();
 }
 

--- a/bench_rescue_prime.cpp
+++ b/bench_rescue_prime.cpp
@@ -144,3 +144,106 @@ benchmark_merge(sycl::queue& q,
 
   return (end - start); // in nanoseconds
 }
+
+uint64_t
+benchmark_merge_using_scratch_pad(sycl::queue& q,
+                                  const uint32_t dim,
+                                  const uint32_t wg_size,
+                                  const uint32_t itr_count)
+{
+  assert(wg_size >= 12);
+
+  sycl::ulong* input_hashes =
+    static_cast<sycl::ulong*>(sycl::malloc_device(sizeof(sycl::ulong) * 8, q));
+  sycl::ulong* merged_hashes = static_cast<sycl::ulong*>(
+    sycl::malloc_device(sizeof(sycl::ulong) * dim * dim * DIGEST_SIZE, q));
+  sycl::ulong4* mds_h = static_cast<sycl::ulong4*>(
+    sycl::malloc_host(sizeof(sycl::ulong4) * STATE_WIDTH * 3, q));
+  sycl::ulong4* ark1_h = static_cast<sycl::ulong4*>(
+    sycl::malloc_host(sizeof(sycl::ulong4) * NUM_ROUNDS * 3, q));
+  sycl::ulong4* ark2_h = static_cast<sycl::ulong4*>(
+    sycl::malloc_host(sizeof(sycl::ulong4) * NUM_ROUNDS * 3, q));
+  sycl::ulong4* mds_d = static_cast<sycl::ulong4*>(
+    sycl::malloc_device(sizeof(sycl::ulong4) * STATE_WIDTH * 3, q));
+  sycl::ulong4* ark1_d = static_cast<sycl::ulong4*>(
+    sycl::malloc_device(sizeof(sycl::ulong4) * NUM_ROUNDS * 3, q));
+  sycl::ulong4* ark2_d = static_cast<sycl::ulong4*>(
+    sycl::malloc_device(sizeof(sycl::ulong4) * NUM_ROUNDS * 3, q));
+
+  prepare_mds(mds_h);
+  prepare_ark1(ark1_h);
+  prepare_ark2(ark2_h);
+
+  sycl::event evt_0 = q.single_task([=]() {
+    for (uint8_t i = 0; i < 8; i++) {
+      *(input_hashes + i) = i;
+    }
+  });
+
+  sycl::event evt_1 =
+    q.memcpy(mds_d, mds_h, sizeof(sycl::ulong4) * STATE_WIDTH * 3);
+  sycl::event evt_2 =
+    q.memcpy(ark1_d, ark1_h, sizeof(sycl::ulong4) * NUM_ROUNDS * 3);
+  sycl::event evt_3 =
+    q.memcpy(ark2_d, ark2_h, sizeof(sycl::ulong4) * NUM_ROUNDS * 3);
+
+  sycl::event evt_4 = q.submit([&](sycl::handler& h) {
+    scratch_mem_1d_t mds_loc =
+      scratch_mem_1d_t{ sycl::range<1>{ STATE_WIDTH * 3 }, h };
+    scratch_mem_1d_t ark1_loc =
+      scratch_mem_1d_t{ sycl::range<1>{ NUM_ROUNDS * 3 }, h };
+    scratch_mem_1d_t ark2_loc =
+      scratch_mem_1d_t{ sycl::range<1>{ NUM_ROUNDS * 3 }, h };
+
+    h.depends_on({ evt_0, evt_1, evt_2, evt_3 });
+    h.parallel_for<class kernelBenchmarkRescuePrimeMergeHashesUsingScratchPad>(
+      sycl::nd_range<2>{ sycl::range<2>{ dim, dim },
+                         sycl::range<2>{ 1, wg_size } },
+      [=](sycl::nd_item<2> it) {
+        const size_t idx = it.get_global_linear_id();
+        sycl::group grp = it.get_group();
+
+        if (idx % 12 == idx) {
+          for (size_t j = 0; j < 3; j++) {
+            mds_loc[j * 12 + idx] = mds_d[j * 12 + idx];
+          }
+        }
+
+        if (idx % 7 == idx) {
+          for (size_t j = 0; j < 3; j++) {
+            ark1_loc[j * 7 + idx] = ark1_d[j * 7 + idx];
+          }
+
+          for (size_t j = 0; j < 3; j++) {
+            ark2_loc[j * 7 + idx] = ark2_d[j * 7 + idx];
+          }
+        }
+
+        // ensure all rescue prime constants written into local memory
+        // and visiable to all work-items in work-group
+        sycl::group_barrier(grp, sycl::memory_scope::work_group);
+
+        for (uint32_t i = 0; i < itr_count; i++) {
+          merge(
+            input_hashes, merged_hashes + idx * 4, mds_loc, ark1_loc, ark2_loc);
+        }
+      });
+  });
+  evt_4.wait();
+
+  uint64_t start =
+    evt_4.get_profiling_info<sycl::info::event_profiling::command_start>();
+  uint64_t end =
+    evt_4.get_profiling_info<sycl::info::event_profiling::command_end>();
+
+  sycl::free(input_hashes, q);
+  sycl::free(merged_hashes, q);
+  sycl::free(mds_h, q);
+  sycl::free(ark1_h, q);
+  sycl::free(ark2_h, q);
+  sycl::free(mds_d, q);
+  sycl::free(ark1_d, q);
+  sycl::free(ark2_d, q);
+
+  return (end - start); // in nanoseconds
+}

--- a/bench_rescue_prime.cpp
+++ b/bench_rescue_prime.cpp
@@ -201,26 +201,30 @@ benchmark_merge_using_scratch_pad(sycl::queue& q,
                          sycl::range<2>{ 1, wg_size } },
       [=](sycl::nd_item<2> it) {
         const size_t idx = it.get_global_linear_id();
+        const size_t loc_idx = it.get_local_linear_id();
         sycl::group grp = it.get_group();
 
-        if (idx % 12 == idx) {
+        if (loc_idx % 12 == loc_idx) {
           for (size_t j = 0; j < 3; j++) {
-            mds_loc[j * 12 + idx] = mds_d[j * 12 + idx];
+            const size_t k = j * 12 + loc_idx;
+            mds_loc[k] = mds_d[k];
           }
         }
 
-        if (idx % 7 == idx) {
+        if (loc_idx % 7 == loc_idx) {
           for (size_t j = 0; j < 3; j++) {
-            ark1_loc[j * 7 + idx] = ark1_d[j * 7 + idx];
+            const size_t k = j * 7 + loc_idx;
+            ark1_loc[k] = ark1_d[k];
           }
 
           for (size_t j = 0; j < 3; j++) {
-            ark2_loc[j * 7 + idx] = ark2_d[j * 7 + idx];
+            const size_t k = j * 7 + loc_idx;
+            ark2_loc[k] = ark2_d[k];
           }
         }
 
         // ensure all rescue prime constants written into local memory
-        // and visiable to all work-items in work-group
+        // and visible to all work-items in work-group
         sycl::group_barrier(grp, sycl::memory_scope::work_group);
 
         for (uint32_t i = 0; i < itr_count; i++) {

--- a/benchmarks/cuda_merkle_tree.md
+++ b/benchmarks/cuda_merkle_tree.md
@@ -16,27 +16,27 @@ running on Tesla V100-SXM2-16GB
 Merklize ( approach 1 ) using Rescue Prime on F(2**64 - 2**32 + 1) elements 👇
 
      leaves		          total
-    1048576		        63.1821 ms
-    2097152		         116.28 ms
-    4194304		        221.659 ms
-    8388608		        431.678 ms
-   16777216		        851.845 ms
+    1048576		        63.1163 ms
+    2097152		        116.267 ms
+    4194304		        219.799 ms
+    8388608		        431.501 ms
+   16777216		        849.147 ms
 
 Merklize ( approach 2 ) using Rescue Prime on F(2**64 - 2**32 + 1) elements 👇
 
      leaves		          total
-    1048576		         122.44 ms
-    2097152		        231.703 ms
-    4194304		        449.037 ms
-    8388608		        881.705 ms
-   16777216		        1745.14 ms
+    1048576		        122.429 ms
+    2097152		        231.646 ms
+    4194304		        449.042 ms
+    8388608		        886.979 ms
+   16777216		        1746.06 ms
 
 Merklize ( approach 3 ) using Rescue Prime on F(2**64 - 2**32 + 1) elements 👇
 
      leaves		          total
-    1048576		        63.2559 ms
-    2097152		        116.025 ms
-    4194304		        221.412 ms
-    8388608		        417.309 ms
-   16777216		        778.676 ms
+    1048576		        63.1895 ms
+    2097152		        114.592 ms
+    4194304		        212.439 ms
+    8388608		        415.004 ms
+   16777216		        792.812 ms
 ```

--- a/benchmarks/cuda_merkle_tree.md
+++ b/benchmarks/cuda_merkle_tree.md
@@ -2,9 +2,9 @@
 
 In benchmarking code, I construct all intermediate nodes of Binary Merkle Tree, where N -many leaves are provided. Each leaf is a Rescue Prime digest and Rescue Prime function `merge` is used for merging two children nodes & computing immediate parent node ( which is intermediate node, indeed ). Note, in all these case N must be power of 2. Each digest of Rescue Prime hash is 4 field elements ( i.e. 256 -bit ) wide. After Merklization (N - 1) -many intermediate nodes to be computed. 
 
-I've applied two approaches in writing Merklization routine. Their underlying assumptions are similar, it's just that how work is distributed or more specifically speaking which work-item is orchestrated to do what  is different. 
+I've applied three approaches in writing Merklization routine. Their underlying assumptions are similar, it's just that how work is distributed or more specifically speaking which work-item is orchestrated to do what is different along with whether Rescue Prime hash constants are read from global memory or cheaper scratch pad memory. Latest routine ( i.e. `approach 3` ) uses local scratch pad memory, otherwise it's very much same as what `approach 1` is.
 
-> I plan to write a detailed description/ comparison of both of these approaches. [ **WIP** ]
+> You may want to read [this post](https://itzmeanjan.in/pages/evaluate-merklizaion-design-performance-in-sycl.html) for understanding difference in between `approach {1, 2}`.
 
 ```bash
 DEVICE=gpu make cuda && ./run
@@ -16,16 +16,27 @@ running on Tesla V100-SXM2-16GB
 Merklize ( approach 1 ) using Rescue Prime on F(2**64 - 2**32 + 1) elements 👇
 
      leaves		          total
-    1048576		        63.0723 ms
-    2097152		        116.168 ms
-    4194304		        221.621 ms
-    8388608		        431.217 ms
+    1048576		        63.1821 ms
+    2097152		         116.28 ms
+    4194304		        221.659 ms
+    8388608		        431.678 ms
+   16777216		        851.845 ms
 
 Merklize ( approach 2 ) using Rescue Prime on F(2**64 - 2**32 + 1) elements 👇
 
      leaves		          total
-    1048576		        136.805 ms
-    2097152		        238.906 ms
-    4194304		        445.335 ms
-    8388608		        873.742 ms
+    1048576		         122.44 ms
+    2097152		        231.703 ms
+    4194304		        449.037 ms
+    8388608		        881.705 ms
+   16777216		        1745.14 ms
+
+Merklize ( approach 3 ) using Rescue Prime on F(2**64 - 2**32 + 1) elements 👇
+
+     leaves		          total
+    1048576		        63.2559 ms
+    2097152		        116.025 ms
+    4194304		        221.412 ms
+    8388608		        417.309 ms
+   16777216		        778.676 ms
 ```

--- a/include/bench_merkle_tree.hpp
+++ b/include/bench_merkle_tree.hpp
@@ -16,3 +16,14 @@ uint64_t
 benchmark_merklize_approach_2(sycl::queue& q,
                               const size_t leaf_count,
                               const size_t wg_size);
+
+// Benchmarks third merklization implementation, which uses
+// local scratch pad memory for storing rescue prime constants
+//
+// Returns total kernel execution time in nanosecond level granularity
+//
+// Ensure SYCL queue has profiling enabled !
+uint64_t
+benchmark_merklize_approach_3(sycl::queue& q,
+                              const size_t leaf_count,
+                              const size_t wg_size);

--- a/include/bench_rescue_prime.hpp
+++ b/include/bench_rescue_prime.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <CL/sycl.hpp>
+#include <cassert>
 
 // Kernel execution time returned in nanoseconds
 uint64_t
@@ -14,3 +15,14 @@ benchmark_merge(sycl::queue& q,
                 const uint32_t dim,
                 const uint32_t wg_size,
                 const uint32_t itr_count);
+
+// Benchmarks rescue prime merge function which uses local scratch pad
+// memory for storing rescue constants
+//
+// Returned number is kernel execution time on accelerator with
+// nanosecond level granularity
+uint64_t
+benchmark_merge_using_scratch_pad(sycl::queue& q,
+                                  const uint32_t dim,
+                                  const uint32_t wg_size,
+                                  const uint32_t itr_count);

--- a/include/merkle_tree.hpp
+++ b/include/merkle_tree.hpp
@@ -46,3 +46,18 @@ merklize_approach_2(sycl::queue& q,
                     const sycl::ulong4* mds,
                     const sycl::ulong4* ark1,
                     const sycl::ulong4* ark2);
+
+// Re-implemented approach 1, while using local scratch pad memory for storing
+// rescue prime hash constants
+//
+// An experimental attempt at improving Merklization performance
+// while leveraging GPU memory hierarchy in better fashion
+uint64_t
+merklize_approach_3(sycl::queue& q,
+                    const sycl::ulong* leaves,
+                    sycl::ulong* const intermediates,
+                    const size_t leaf_count,
+                    const size_t wg_size,
+                    const sycl::ulong4* mds,
+                    const sycl::ulong4* ark1,
+                    const sycl::ulong4* ark2);

--- a/include/rescue_prime.hpp
+++ b/include/rescue_prime.hpp
@@ -60,6 +60,19 @@ ff_p_vec_add(const sycl::ulong4* a,
 SYCL_EXTERNAL void
 apply_sbox(const sycl::ulong4* state_in, sycl::ulong4* const state_out);
 
+// Applies rescue round key constants on hash state while reading
+// constants from faster local memory, which should hopefully
+// benefit me in long run
+//
+// Implementation is same as original `apply_constants`, just that
+// local memory accessor is offset by provided factor to use correct
+// round key constants
+SYCL_EXTERNAL void
+apply_constants(const sycl::ulong4* state_in,
+                scratch_mem_1d_t cnst,
+                const size_t cnst_offset,
+                sycl::ulong4* const state_out);
+
 // Applies rescue round key constants on hash state
 //
 // actually simple vectorized modular addition --- that's all this routine does

--- a/include/rescue_prime.hpp
+++ b/include/rescue_prime.hpp
@@ -150,6 +150,19 @@ exp_acc(const sycl::ulong m,
 SYCL_EXTERNAL void
 apply_inv_sbox(const sycl::ulong4* state_in, sycl::ulong4* const state_out);
 
+// Applies a single round of rescue permutation, while reading all rescue
+// constants from local memory
+//
+// Note, implementation wise no major difference between these two overloaded
+// variants expect usage of local scratch pad memory
+SYCL_EXTERNAL void
+apply_permutation_round(const sycl::ulong4* state_in,
+                        scratch_mem_1d_t mds,
+                        scratch_mem_1d_t ark1,
+                        scratch_mem_1d_t ark2,
+                        const size_t ark_offset,
+                        sycl::ulong4* const state_out);
+
 // Apply a round of rescue permutation, which mixes/ consumes input into hash
 // state
 //
@@ -161,6 +174,18 @@ apply_permutation_round(const sycl::ulong4* state_in,
                         const sycl::ulong4* ark1,
                         const sycl::ulong4* ark2,
                         sycl::ulong4* const state_out);
+
+// Applies all 7 rescue permutation rounds on hash state, consuming input ( till
+// now ) into state, while reading all hash constants from local memory
+//
+// Note, implementation wise no major difference between these two overloaded
+// variants expect usage of local scratch pad memory
+SYCL_EXTERNAL void
+apply_rescue_permutation(const sycl::ulong4* state_in,
+                         scratch_mem_1d_t mds,
+                         scratch_mem_1d_t ark1,
+                         scratch_mem_1d_t ark2,
+                         sycl::ulong4* const state_out);
 
 // Applies all rounds ( = 7 ) of rescue permutation, updating hash state
 //
@@ -180,6 +205,19 @@ apply_rescue_permutation(const sycl::ulong4* state_in,
                          const sycl::ulong4* ark2,
                          sycl::ulong4* const state_out);
 
+// Computes rescue prime hash digest ( of 256 -bit width )
+// from input prime field elements array, while reading all rescue constants
+// from local memory
+//
+// Implementation wise it's very similar to other overloaded variant
+SYCL_EXTERNAL void
+hash_elements(const sycl::ulong* input_elements,
+              const sycl::ulong count,
+              sycl::ulong* const hash,
+              scratch_mem_1d_t mds,
+              scratch_mem_1d_t ark1,
+              scratch_mem_1d_t ark2);
+
 // Computes rescue prime hash of input prime field elements, by consuming
 // all input elements into 12 elements wide hash state
 //
@@ -192,6 +230,20 @@ hash_elements(const sycl::ulong* input_elements,
               const sycl::ulong4* mds,
               const sycl::ulong4* ark1,
               const sycl::ulong4* ark2);
+
+// Merges two rescue prime digests into single digest of 256 -bit width, where
+// input is of width 512 -bit
+//
+// In this implementation all rescue constants are read from faster local memory
+//
+// Note, implementation wise no major changes are present in between two
+// overloaded variants
+SYCL_EXTERNAL void
+merge(const sycl::ulong* input_hashes,
+      sycl::ulong* const merged_hash,
+      scratch_mem_1d_t mds,
+      scratch_mem_1d_t ark1,
+      scratch_mem_1d_t ark2);
 
 // Merges two rescue prime digests into single digest of width 256 -bit
 //

--- a/include/test_merkle_tree.hpp
+++ b/include/test_merkle_tree.hpp
@@ -1,7 +1,7 @@
 #pragma once
+#include <cassert>
 #include <merkle_tree.hpp>
 #include <random>
-#include <cassert>
 
 // Test that merkle tree construction kernel is working as expected !
 void

--- a/main.cpp
+++ b/main.cpp
@@ -56,9 +56,9 @@ main(int argc, char** argv)
               << 1e9 / ((double)tm / (double)(dim * dim * 1)) << std::endl;
   }
 
-  std::cout
-    << "\nRescue prime merge hashes on F(2**64 - 2**32 + 1) elements 👇\n"
-    << std::endl;
+  std::cout << "\nRescue prime merge hashes ( using global memory ) on F(2**64 "
+               "- 2**32 + 1) elements 👇\n"
+            << std::endl;
   std::cout << std::setw(11) << "dimension"
             << "\t\t" << std::setw(10) << "iterations"
             << "\t\t" << std::setw(15) << "total"
@@ -68,6 +68,28 @@ main(int argc, char** argv)
   for (uint dim = B; dim <= (1ul << 12); dim <<= 1) {
     // time in nanoseconds --- beware !
     uint64_t tm = benchmark_merge(q, dim, 1ul << 6, 1);
+
+    std::cout << std::setw(5) << std::left << dim << "x" << std::setw(5)
+              << std::right << dim << "\t\t" << std::setw(8) << std::right << 1
+              << "\t\t" << std::setw(15) << std::right << tm << " ns"
+              << "\t\t" << std::setw(15) << std::right
+              << (double)tm / (double)(dim * dim * 1) << " ns"
+              << "\t\t" << std::setw(15) << std::right
+              << 1e9 / ((double)tm / (double)(dim * dim * 1)) << std::endl;
+  }
+
+  std::cout << "\nRescue prime merge hashes ( using scratch pad ) on F(2**64 - "
+               "2**32 + 1) elements 👇\n"
+            << std::endl;
+  std::cout << std::setw(11) << "dimension"
+            << "\t\t" << std::setw(10) << "iterations"
+            << "\t\t" << std::setw(15) << "total"
+            << "\t\t" << std::setw(20) << "avg"
+            << "\t\t" << std::setw(20) << "op/s" << std::endl;
+
+  for (uint dim = B; dim <= (1ul << 12); dim <<= 1) {
+    // time in nanoseconds --- beware !
+    uint64_t tm = benchmark_merge_using_scratch_pad(q, dim, 1ul << 6, 1);
 
     std::cout << std::setw(5) << std::left << dim << "x" << std::setw(5)
               << std::right << dim << "\t\t" << std::setw(8) << std::right << 1

--- a/main.cpp
+++ b/main.cpp
@@ -106,7 +106,7 @@ main(int argc, char** argv)
   std::cout << std::setw(11) << "leaves"
             << "\t\t" << std::setw(15) << "total" << std::endl;
 
-  for (uint dim = (1ul << 20); dim <= (1ul << 23); dim <<= 1) {
+  for (uint dim = (1ul << 20); dim <= (1ul << 24); dim <<= 1) {
     // time in nanoseconds --- beware !
     uint64_t tm = benchmark_merklize_approach_1(q, dim, 1ul << 5);
 
@@ -120,7 +120,7 @@ main(int argc, char** argv)
   std::cout << std::setw(11) << "leaves"
             << "\t\t" << std::setw(15) << "total" << std::endl;
 
-  for (uint dim = (1ul << 20); dim <= (1ul << 23); dim <<= 1) {
+  for (uint dim = (1ul << 20); dim <= (1ul << 24); dim <<= 1) {
     // time in nanoseconds --- beware !
     uint64_t tm = benchmark_merklize_approach_2(q, dim, 1ul << 5);
 
@@ -134,7 +134,7 @@ main(int argc, char** argv)
   std::cout << std::setw(11) << "leaves"
             << "\t\t" << std::setw(15) << "total" << std::endl;
 
-  for (uint dim = (1ul << 20); dim <= (1ul << 23); dim <<= 1) {
+  for (uint dim = (1ul << 20); dim <= (1ul << 24); dim <<= 1) {
     // time in nanoseconds --- beware !
     uint64_t tm = benchmark_merklize_approach_3(q, dim, 1ul << 5);
 

--- a/main.cpp
+++ b/main.cpp
@@ -151,7 +151,7 @@ main(int argc, char** argv)
     int64_t tm = benchmark_forward_transform(q, dim, B);
 
     std::cout << std::setw(5) << std::right << dim << "\t\t" << std::setw(15)
-              << std::right << tm << " ms" << std::endl;
+              << std::right << tm << " us" << std::endl;
   }
 
   std::cout << "\nInverse NTT on F(2**64 - 2**32 + 1) elements 👇\n"
@@ -163,7 +163,7 @@ main(int argc, char** argv)
     int64_t tm = benchmark_inverse_transform(q, dim, B);
 
     std::cout << std::setw(5) << std::right << dim << "\t\t" << std::setw(15)
-              << std::right << tm << " ms" << std::endl;
+              << std::right << tm << " us" << std::endl;
   }
 
   std::cout << "\nCooley-Tukey FFT on F(2**64 - 2**32 + 1) elements 👇\n"

--- a/main.cpp
+++ b/main.cpp
@@ -128,6 +128,20 @@ main(int argc, char** argv)
               << std::right << tm * 1e-6 << " ms" << std::endl;
   }
 
+  std::cout << "\nMerklize ( approach 3 ) using Rescue Prime on F(2**64 - "
+               "2**32 + 1) elements 👇\n"
+            << std::endl;
+  std::cout << std::setw(11) << "leaves"
+            << "\t\t" << std::setw(15) << "total" << std::endl;
+
+  for (uint dim = (1ul << 20); dim <= (1ul << 23); dim <<= 1) {
+    // time in nanoseconds --- beware !
+    uint64_t tm = benchmark_merklize_approach_3(q, dim, 1ul << 5);
+
+    std::cout << std::setw(11) << std::right << dim << "\t\t" << std::setw(15)
+              << std::right << tm * 1e-6 << " ms" << std::endl;
+  }
+
   std::cout << "\nForward NTT on F(2**64 - 2**32 + 1) elements 👇\n"
             << std::endl;
   std::cout << std::setw(5) << "dimension"

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@ using namespace sycl;
 
 const uint32_t N = 1 << 10;
 const uint32_t B = 1 << 7;
+const size_t BENCH_ROUND = 4;
 
 int
 main(int argc, char** argv)
@@ -108,7 +109,12 @@ main(int argc, char** argv)
 
   for (uint dim = (1ul << 20); dim <= (1ul << 24); dim <<= 1) {
     // time in nanoseconds --- beware !
-    uint64_t tm = benchmark_merklize_approach_1(q, dim, 1ul << 5);
+    double tm = 0;
+    for (size_t i = 0; i < BENCH_ROUND; i++) {
+      tm +=
+        static_cast<double>(benchmark_merklize_approach_1(q, dim, 1ul << 5));
+    }
+    tm /= static_cast<double>(BENCH_ROUND);
 
     std::cout << std::setw(11) << std::right << dim << "\t\t" << std::setw(15)
               << std::right << tm * 1e-6 << " ms" << std::endl;
@@ -122,7 +128,12 @@ main(int argc, char** argv)
 
   for (uint dim = (1ul << 20); dim <= (1ul << 24); dim <<= 1) {
     // time in nanoseconds --- beware !
-    uint64_t tm = benchmark_merklize_approach_2(q, dim, 1ul << 5);
+    double tm = 0;
+    for (size_t i = 0; i < BENCH_ROUND; i++) {
+      tm +=
+        static_cast<double>(benchmark_merklize_approach_2(q, dim, 1ul << 5));
+    }
+    tm /= static_cast<double>(BENCH_ROUND);
 
     std::cout << std::setw(11) << std::right << dim << "\t\t" << std::setw(15)
               << std::right << tm * 1e-6 << " ms" << std::endl;
@@ -136,7 +147,12 @@ main(int argc, char** argv)
 
   for (uint dim = (1ul << 20); dim <= (1ul << 24); dim <<= 1) {
     // time in nanoseconds --- beware !
-    uint64_t tm = benchmark_merklize_approach_3(q, dim, 1ul << 5);
+    double tm = 0;
+    for (size_t i = 0; i < BENCH_ROUND; i++) {
+      tm +=
+        static_cast<double>(benchmark_merklize_approach_3(q, dim, 1ul << 5));
+    }
+    tm /= static_cast<double>(BENCH_ROUND);
 
     std::cout << std::setw(11) << std::right << dim << "\t\t" << std::setw(15)
               << std::right << tm * 1e-6 << " ms" << std::endl;

--- a/merkle_tree.cpp
+++ b/merkle_tree.cpp
@@ -223,3 +223,203 @@ merklize_approach_2(sycl::queue& q,
 
   return ts;
 }
+
+uint64_t
+merklize_approach_3(sycl::queue& q,
+                    const sycl::ulong* leaves,
+                    sycl::ulong* const intermediates,
+                    const size_t leaf_count,
+                    const size_t wg_size,
+                    const sycl::ulong4* mds,
+                    const sycl::ulong4* ark1,
+                    const sycl::ulong4* ark2)
+{
+  // ensure only working with powers of 2 -many leaves
+  assert((leaf_count & (leaf_count - 1)) == 0);
+  // checking that requested work group size for first
+  // phase of kernel dispatch is valid
+  //
+  // for next rounds of kernel dispatches, work group
+  // size will be adapted when required !
+  assert(wg_size <= (leaf_count >> 1));
+
+  const size_t output_offset = leaf_count >> 1;
+
+  // this is first phase of kernel dispatch, where I compute
+  // ( in parallel ) all intermediate nodes just above leaves of tree
+  sycl::event evt_0 = q.submit([&](sycl::handler& h) {
+    if (wg_size >= 12) {
+      scratch_mem_1d_t mds_loc =
+        scratch_mem_1d_t{ sycl::range<1>{ STATE_WIDTH * 3 }, h };
+      scratch_mem_1d_t ark1_loc =
+        scratch_mem_1d_t{ sycl::range<1>{ NUM_ROUNDS * 3 }, h };
+      scratch_mem_1d_t ark2_loc =
+        scratch_mem_1d_t{ sycl::range<1>{ NUM_ROUNDS * 3 }, h };
+
+      h.parallel_for<
+        class kernelMerklizeRescuePrimeApproach3Phase0UsingScratchPad>(
+        sycl::nd_range<1>{ sycl::range<1>{ output_offset },
+                           sycl::range<1>{ wg_size } },
+        [=](sycl::nd_item<1> it) {
+          const size_t idx = it.get_global_linear_id();
+          const size_t loc_idx = it.get_local_linear_id();
+          sycl::group grp = it.get_group();
+
+          if (loc_idx % 12 == loc_idx) {
+            for (size_t j = 0; j < 3; j++) {
+              const size_t k = j * 12 + loc_idx;
+              mds_loc[k] = mds[k];
+            }
+          }
+
+          if (loc_idx % 7 == loc_idx) {
+            for (size_t j = 0; j < 3; j++) {
+              const size_t k = j * 7 + loc_idx;
+              ark1_loc[k] = ark1[k];
+            }
+
+            for (size_t j = 0; j < 3; j++) {
+              const size_t k = j * 7 + loc_idx;
+              ark2_loc[k] = ark2[k];
+            }
+          }
+
+          // ensure all rescue prime constants written into local memory
+          // and visible to all work-items in work-group
+          sycl::group_barrier(grp, sycl::memory_scope::work_group);
+
+          merge(leaves + idx * (DIGEST_SIZE >> 1),
+                intermediates + (output_offset + idx) * DIGEST_SIZE,
+                mds_loc,
+                ark1_loc,
+                ark2_loc);
+        });
+    } else {
+      h.parallel_for<
+        class kernelMerklizeRescuePrimeApproach3Phase0UsingGlobalMem>(
+        sycl::nd_range<1>{ sycl::range<1>{ output_offset },
+                           sycl::range<1>{ wg_size } },
+        [=](sycl::nd_item<1> it) {
+          const size_t idx = it.get_global_linear_id();
+
+          merge(leaves + idx * (DIGEST_SIZE >> 1),
+                intermediates + (output_offset + idx) * DIGEST_SIZE,
+                mds,
+                ark1,
+                ark2);
+        });
+    }
+  });
+
+  // for computing all remaining intermediate nodes, we'll need to
+  // dispatch `rounds` -many kernels, where each round is data dependent
+  // on just previous one
+  const size_t rounds =
+    static_cast<size_t>(sycl::log2(static_cast<double>(leaf_count >> 1)));
+
+  std::vector<sycl::event> evts;
+  evts.reserve(rounds);
+
+  for (size_t r = 0; r < rounds; r++) {
+    sycl::event evt = q.submit([&](sycl::handler& h) {
+      if (r == 0) {
+        h.depends_on(evt_0);
+      } else {
+        h.depends_on(evts.at(r - 1));
+      }
+
+      // these many intermediate nodes to be computed during this
+      // kernel dispatch round
+      const size_t offset = leaf_count >> (r + 2);
+      const size_t new_wg_size = offset < wg_size ? offset : wg_size;
+
+      if (new_wg_size >= 12) {
+        scratch_mem_1d_t mds_loc =
+          scratch_mem_1d_t{ sycl::range<1>{ STATE_WIDTH * 3 }, h };
+        scratch_mem_1d_t ark1_loc =
+          scratch_mem_1d_t{ sycl::range<1>{ NUM_ROUNDS * 3 }, h };
+        scratch_mem_1d_t ark2_loc =
+          scratch_mem_1d_t{ sycl::range<1>{ NUM_ROUNDS * 3 }, h };
+
+        h.parallel_for<
+          class kernelMerklizeRescuePrimeApproach3Phase1UsingScratchPad>(
+          sycl::nd_range<1>{ sycl::range<1>{ offset },
+                             sycl::range<1>{ new_wg_size } },
+          [=](sycl::nd_item<1> it) {
+            const size_t idx = it.get_global_linear_id();
+            const size_t loc_idx = it.get_local_linear_id();
+            sycl::group grp = it.get_group();
+
+            if (loc_idx % 12 == loc_idx) {
+              for (size_t j = 0; j < 3; j++) {
+                const size_t k = j * 12 + loc_idx;
+                mds_loc[k] = mds[k];
+              }
+            }
+
+            if (loc_idx % 7 == loc_idx) {
+              for (size_t j = 0; j < 3; j++) {
+                const size_t k = j * 7 + loc_idx;
+                ark1_loc[k] = ark1[k];
+              }
+
+              for (size_t j = 0; j < 3; j++) {
+                const size_t k = j * 7 + loc_idx;
+                ark2_loc[k] = ark2[k];
+              }
+            }
+
+            // ensure all rescue prime constants written into local memory
+            // and visible to all work-items in work-group
+            sycl::group_barrier(grp, sycl::memory_scope::work_group);
+
+            merge(intermediates + (offset << 1) * DIGEST_SIZE +
+                    idx * (DIGEST_SIZE >> 1),
+                  intermediates + (offset + idx) * DIGEST_SIZE,
+                  mds_loc,
+                  ark1_loc,
+                  ark2_loc);
+          });
+      } else {
+        h.parallel_for<
+          class kernelMerklizeRescuePrimeApproach3Phase1UsingGlobalMem>(
+          sycl::nd_range<1>{ sycl::range<1>{ offset },
+                             sycl::range<1>{ new_wg_size } },
+          [=](sycl::nd_item<1> it) {
+            const size_t idx = it.get_global_linear_id();
+
+            merge(intermediates + (offset << 1) * DIGEST_SIZE +
+                    idx * (DIGEST_SIZE >> 1),
+                  intermediates + (offset + idx) * DIGEST_SIZE,
+                  mds,
+                  ark1,
+                  ark2);
+          });
+      }
+    });
+    evts.push_back(evt);
+  }
+
+  evts.at(rounds - 1).wait();
+
+  // calculate sum of dispatched kernel execution times
+  uint64_t ts = 0;
+
+  uint64_t start =
+    evt_0.get_profiling_info<sycl::info::event_profiling::command_start>();
+  uint64_t end =
+    evt_0.get_profiling_info<sycl::info::event_profiling::command_end>();
+
+  ts += (end - start);
+
+  for (sycl::event evt : evts) {
+    uint64_t start =
+      evt.get_profiling_info<sycl::info::event_profiling::command_start>();
+    uint64_t end =
+      evt.get_profiling_info<sycl::info::event_profiling::command_end>();
+
+    ts += (end - start);
+  }
+
+  return ts;
+}

--- a/merkle_tree.cpp
+++ b/merkle_tree.cpp
@@ -176,7 +176,7 @@ merklize_approach_2(sycl::queue& q,
           const size_t loc_size = it.get_local_range(0);
           sycl::group<1> grp = it.get_group();
 
-          sycl::group_barrier(grp, sycl::memory_scope_work_group);
+          sycl::group_barrier(grp, sycl::memory_scope_device);
 
           while ((1 << (round - 1)) < loc_size) {
             if (idx % (1 << round) == 0) {
@@ -189,7 +189,7 @@ merklize_approach_2(sycl::queue& q,
                     ark2);
             }
 
-            sycl::group_barrier(grp, sycl::memory_scope_work_group);
+            sycl::group_barrier(grp, sycl::memory_scope_device);
             round++;
           }
         });

--- a/rescue_prime.cpp
+++ b/rescue_prime.cpp
@@ -110,6 +110,90 @@ accumulate_state(const sycl::ulong4* state)
 
 void
 apply_mds(const sycl::ulong4* state_in,
+          scratch_mem_1d_t mds,
+          sycl::ulong4* const state_out)
+{
+  sycl::ulong4 scratch[3] = {};
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[0]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[1]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[2]);
+
+  sycl::ulong v0 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[3]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[4]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[5]);
+
+  sycl::ulong v1 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[6]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[7]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[8]);
+
+  sycl::ulong v2 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[9]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[10]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[11]);
+
+  sycl::ulong v3 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[12]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[13]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[14]);
+
+  sycl::ulong v4 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[15]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[16]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[17]);
+
+  sycl::ulong v5 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[18]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[19]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[20]);
+
+  sycl::ulong v6 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[21]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[22]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[23]);
+
+  sycl::ulong v7 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[24]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[25]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[26]);
+
+  sycl::ulong v8 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[27]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[28]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[29]);
+
+  sycl::ulong v9 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[30]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[31]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[32]);
+
+  sycl::ulong v10 = accumulate_state(scratch);
+
+  scratch[0] = ff_p_vec_mul_(*(state_in + 0), mds[33]);
+  scratch[1] = ff_p_vec_mul_(*(state_in + 1), mds[34]);
+  scratch[2] = ff_p_vec_mul_(*(state_in + 2), mds[35]);
+
+  sycl::ulong v11 = accumulate_state(scratch);
+
+  *(state_out + 0) = sycl::ulong4(v0, v1, v2, v3);
+  *(state_out + 1) = sycl::ulong4(v4, v5, v6, v7);
+  *(state_out + 2) = sycl::ulong4(v8, v9, v10, v11);
+}
+
+void
+apply_mds(const sycl::ulong4* state_in,
           const sycl::ulong4* mds,
           sycl::ulong4* const state_out)
 {

--- a/rescue_prime.cpp
+++ b/rescue_prime.cpp
@@ -83,6 +83,17 @@ apply_sbox(const sycl::ulong4* state_in, sycl::ulong4* const state_out)
 
 void
 apply_constants(const sycl::ulong4* state_in,
+                scratch_mem_1d_t cnst,
+                const size_t cnst_offset,
+                sycl::ulong4* const state_out)
+{
+  *(state_out + 0) = ff_p_vec_add_(*(state_in + 0), cnst[cnst_offset + 0]);
+  *(state_out + 1) = ff_p_vec_add_(*(state_in + 1), cnst[cnst_offset + 1]);
+  *(state_out + 2) = ff_p_vec_add_(*(state_in + 2), cnst[cnst_offset + 2]);
+}
+
+void
+apply_constants(const sycl::ulong4* state_in,
                 const sycl::ulong4* cnst,
                 sycl::ulong4* const state_out)
 {


### PR DESCRIPTION
I decided to experiment with another Merklization approach ( i.e. approach 3 ) which is very similar to `approach 1` but instead of using global memory for storing Rescue Prime constants ( i.e. MDS matrix, Round Key constants etc. ) it uses local scratch pad memory. As GPUs have dedicated & cheaper local memory, performance improvement is visible.

Approach | Leaf Count | Time
--- | --- | ---
1 | 2^24 | 849.147 ms
2 | 2^24 | 1746.06 ms
3 | 2^24 | 792.812 ms

Approach 3 gets benefited from using local scratch pad memory for caching rescue prime constants per work-group. 

> Note this approach requires a work-group level synchronization with memory fence to ensure all local memory changes are visible to all participating work-item in that work-group. 